### PR TITLE
Throw error when token without permissions is used on integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-vantage
+module github.com/vantage-sh/terraform-provider-vantage
 
 go 1.20
 

--- a/vantage/client.go
+++ b/vantage/client.go
@@ -75,8 +75,14 @@ func (v *vantageClient) AwsProviderInfo() (*AwsProviderInfoResult, error) {
 	}
 
 	out := AwsProviderInfoResult{}
-	err = json.NewDecoder(resp.Body).Decode(&out)
-	return &out, err
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		err = json.NewDecoder(resp.Body).Decode(&out)
+		return &out, err
+	default:
+		return nil, fmt.Errorf("failed to create provider credential: %d", resp.StatusCode)
+	}
 }
 
 // AwsProviderResourceAPIModel describes the API data model.


### PR DESCRIPTION
If you create an API token with only write access, the integrations endpoint (understandably) doesn't return anything.

This surfaces itself as empty responses:

```
terraform apply                                                                                                                                    ☁️   pulumi-ce
data.vantage_aws_provider_info.default: Reading...
data.vantage_aws_provider_info.default: Read complete after 0s

Changes to Outputs:
  + provider_info = {
      + additional_resources_policy = ""
      + autopilot_policy            = ""
      + cloudwatch_metrics_policy   = ""
      + external_id                 = ""
      + iam_role_arn                = ""
      + root_policy                 = ""
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

provider_info = {
  "additional_resources_policy" = ""
  "autopilot_policy" = ""
  "cloudwatch_metrics_policy" = ""
  "external_id" = ""
  "iam_role_arn" = ""
  "root_policy" = ""
}
```

This updates the provider to actually return an error which is returned by the API