### PR TITLE
Use a string for provider IDs

### DIFF
--- a/docs/resources/aws_provider.md
+++ b/docs/resources/aws_provider.md
@@ -25,6 +25,6 @@ Manages an AWS Account Integration.
 
 ### Read-Only
 
-- `id` (Number) Service generated identifier for the the account access.
+- `id` (String) Service generated identifier for the the account access.
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-vantage
+module github.com/vantage-sh/terraform-provider-vantage
 
 go 1.20
 

--- a/vantage/aws_provider_resource.go
+++ b/vantage/aws_provider_resource.go
@@ -97,7 +97,19 @@ func (r AwsProviderResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	err := r.client.DeleteAwsProvider(state.Id.String())
+	id, err := strconv.Atoi(state.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while attempting to delete the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"API Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	err = r.client.DeleteAwsProvider(id)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading AWS Provider",
@@ -115,7 +127,19 @@ func (r AwsProviderResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	out, err := r.client.GetAwsProvider(state.Id.ValueString())
+	id, err := strconv.Atoi(state.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Update Resource",
+			"An unexpected error occurred while attempting to update the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"API Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	out, err := r.client.GetAwsProvider(id)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading AWS Provider",

--- a/vantage/aws_provider_resource.go
+++ b/vantage/aws_provider_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -82,7 +83,7 @@ func (r AwsProviderResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Convert from the API data model to the Terraform data model
 	// and set any unknown attribute values.
-	data.Id = types.StringValue(provider.Id)
+	data.Id = types.StringValue(strconv.Itoa(provider.Id))
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -153,9 +154,21 @@ func (r AwsProviderResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	id, err := strconv.Atoi(data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Update Resource",
+			"An unexpected error occurred while attempting to update the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"API Error: "+err.Error(),
+		)
+
+		return
+	}
+
 	// Convert from Terraform data model into API data model
 	updateRequest := AwsProviderResourceAPIModel{
-		Id:              data.Id.ValueString(),
+		Id:              id,
 		CrossAccountARN: data.CrossAccountARN.ValueString(),
 		BucketARN:       data.BucketARN.ValueString(),
 	}
@@ -174,7 +187,7 @@ func (r AwsProviderResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Convert from the API data model to the Terraform data model
 	// and set any unknown attribute values.
-	data.Id = types.StringValue(provider.Id)
+	data.Id = types.StringValue(strconv.Itoa(provider.Id))
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/vantage/aws_provider_resource.go
+++ b/vantage/aws_provider_resource.go
@@ -22,7 +22,7 @@ func NewAwsProviderResource() resource.Resource {
 type AwsProviderResourceModel struct {
 	CrossAccountARN types.String `tfsdk:"cross_account_arn"`
 	BucketARN       types.String `tfsdk:"bucket_arn"`
-	Id              types.Int64  `tfsdk:"id"`
+	Id              types.String  `tfsdk:"id"`
 }
 
 func (r *AwsProviderResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -82,7 +82,7 @@ func (r AwsProviderResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Convert from the API data model to the Terraform data model
 	// and set any unknown attribute values.
-	data.Id = types.Int64Value(int64(provider.Id))
+	data.Id = types.StringValue(provider.Id)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -96,11 +96,11 @@ func (r AwsProviderResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	err := r.client.DeleteAwsProvider(int(state.Id.ValueInt64()))
+	err := r.client.DeleteAwsProvider(state.Id.String())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading AWS Provider",
-			fmt.Sprintf("Could not read AWS Provider ID %d: %v", state.Id.ValueInt64(), err.Error()),
+			fmt.Sprintf("Could not read AWS Provider ID %d: %v", state.Id.ValueString(), err.Error()),
 		)
 		return
 	}
@@ -114,11 +114,11 @@ func (r AwsProviderResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	out, err := r.client.GetAwsProvider(int(state.Id.ValueInt64()))
+	out, err := r.client.GetAwsProvider(state.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading AWS Provider",
-			fmt.Sprintf("Could not read AWS Provider ID %d: %v", state.Id.ValueInt64(), err.Error()),
+			fmt.Sprintf("Could not read AWS Provider ID %d: %v", state.Id.ValueString(), err.Error()),
 		)
 		return
 	}
@@ -155,7 +155,7 @@ func (r AwsProviderResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Convert from Terraform data model into API data model
 	updateRequest := AwsProviderResourceAPIModel{
-		Id:              int(data.Id.ValueInt64()),
+		Id:              data.Id.ValueString(),
 		CrossAccountARN: data.CrossAccountARN.ValueString(),
 		BucketARN:       data.BucketARN.ValueString(),
 	}
@@ -174,7 +174,7 @@ func (r AwsProviderResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Convert from the API data model to the Terraform data model
 	// and set any unknown attribute values.
-	data.Id = types.Int64Value(int64(provider.Id))
+	data.Id = types.StringValue(provider.Id)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/vantage/aws_provider_resource.go
+++ b/vantage/aws_provider_resource.go
@@ -22,7 +22,7 @@ func NewAwsProviderResource() resource.Resource {
 type AwsProviderResourceModel struct {
 	CrossAccountARN types.String `tfsdk:"cross_account_arn"`
 	BucketARN       types.String `tfsdk:"bucket_arn"`
-	Id              types.String  `tfsdk:"id"`
+	Id              types.String `tfsdk:"id"`
 }
 
 func (r *AwsProviderResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -40,7 +40,7 @@ func (r AwsProviderResource) Schema(ctx context.Context, req resource.SchemaRequ
 				MarkdownDescription: "Bucket ARN for where CUR data is being stored.",
 				Optional:            true,
 			},
-			"id": schema.Int64Attribute{
+			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Service generated identifier for the the account access.",
 				//PlanModifiers: planmodifier.String{
@@ -100,7 +100,7 @@ func (r AwsProviderResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading AWS Provider",
-			fmt.Sprintf("Could not read AWS Provider ID %d: %v", state.Id.ValueString(), err.Error()),
+			fmt.Sprintf("Could not read AWS Provider ID %s: %v", state.Id.ValueString(), err.Error()),
 		)
 		return
 	}
@@ -118,7 +118,7 @@ func (r AwsProviderResource) Read(ctx context.Context, req resource.ReadRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading AWS Provider",
-			fmt.Sprintf("Could not read AWS Provider ID %d: %v", state.Id.ValueString(), err.Error()),
+			fmt.Sprintf("Could not read AWS Provider ID %s: %v", state.Id.ValueString(), err.Error()),
 		)
 		return
 	}

--- a/vantage/aws_provider_resource.go
+++ b/vantage/aws_provider_resource.go
@@ -113,7 +113,7 @@ func (r AwsProviderResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading AWS Provider",
-			fmt.Sprintf("Could not read AWS Provider ID %s: %v", state.Id.ValueString(), err.Error()),
+			fmt.Sprintf("Could not delete AWS Provider ID %s: %v", state.Id.ValueString(), err.Error()),
 		)
 		return
 	}

--- a/vantage/client.go
+++ b/vantage/client.go
@@ -87,7 +87,7 @@ func (v *vantageClient) AwsProviderInfo() (*AwsProviderInfoResult, error) {
 
 // AwsProviderResourceAPIModel describes the API data model.
 type AwsProviderResourceAPIModel struct {
-	Id              string `json:"id"`
+	Id              int `json:"id"`
 	CrossAccountARN string `json:"cross_account_arn"`
 	BucketARN       string `json:"bucket_arn"`
 }
@@ -130,7 +130,7 @@ func (v *vantageClient) AddAwsProvider(in AwsProviderResourceAPIModel) (*AwsProv
 }
 
 func (v *vantageClient) UpdateAwsProvider(in AwsProviderResourceAPIModel) (*AwsProviderResourceAPIModel, error) {
-	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%s", in.Id))
+	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%d", in.Id))
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (v *vantageClient) UpdateAwsProvider(in AwsProviderResourceAPIModel) (*AwsP
 }
 
 func (v *vantageClient) GetAwsProvider(id string) (*AwsProviderResourceAPIModel, error) {
-	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%s", id))
+	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%d", id))
 	if err != nil {
 		return nil, err
 	}

--- a/vantage/client.go
+++ b/vantage/client.go
@@ -198,7 +198,7 @@ func (v *vantageClient) GetAwsProvider(id int) (*AwsProviderResourceAPIModel, er
 }
 
 func (v *vantageClient) DeleteAwsProvider(id int) error {
-	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%s", id))
+	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%d", id))
 	if err != nil {
 		return err
 	}

--- a/vantage/client.go
+++ b/vantage/client.go
@@ -166,7 +166,7 @@ func (v *vantageClient) UpdateAwsProvider(in AwsProviderResourceAPIModel) (*AwsP
 	}
 }
 
-func (v *vantageClient) GetAwsProvider(id string) (*AwsProviderResourceAPIModel, error) {
+func (v *vantageClient) GetAwsProvider(id int) (*AwsProviderResourceAPIModel, error) {
 	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%d", id))
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func (v *vantageClient) GetAwsProvider(id string) (*AwsProviderResourceAPIModel,
 	}
 }
 
-func (v *vantageClient) DeleteAwsProvider(id string) error {
+func (v *vantageClient) DeleteAwsProvider(id int) error {
 	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%s", id))
 	if err != nil {
 		return err

--- a/vantage/client.go
+++ b/vantage/client.go
@@ -75,8 +75,14 @@ func (v *vantageClient) AwsProviderInfo() (*AwsProviderInfoResult, error) {
 	}
 
 	out := AwsProviderInfoResult{}
-	err = json.NewDecoder(resp.Body).Decode(&out)
-	return &out, err
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		err = json.NewDecoder(resp.Body).Decode(&out)
+		return &out, err
+	default:
+		return nil, fmt.Errorf("failed to create provider credential: %d", resp.StatusCode)
+	}
 }
 
 // AwsProviderResourceAPIModel describes the API data model.

--- a/vantage/client.go
+++ b/vantage/client.go
@@ -87,7 +87,7 @@ func (v *vantageClient) AwsProviderInfo() (*AwsProviderInfoResult, error) {
 
 // AwsProviderResourceAPIModel describes the API data model.
 type AwsProviderResourceAPIModel struct {
-	Id              int    `json:"id"`
+	Id              string    `json:"id"`
 	CrossAccountARN string `json:"cross_account_arn"`
 	BucketARN       string `json:"bucket_arn"`
 }
@@ -166,8 +166,8 @@ func (v *vantageClient) UpdateAwsProvider(in AwsProviderResourceAPIModel) (*AwsP
 	}
 }
 
-func (v *vantageClient) GetAwsProvider(id int) (*AwsProviderResourceAPIModel, error) {
-	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%d", id))
+func (v *vantageClient) GetAwsProvider(id string) (*AwsProviderResourceAPIModel, error) {
+	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%s", id))
 	if err != nil {
 		return nil, err
 	}
@@ -197,8 +197,8 @@ func (v *vantageClient) GetAwsProvider(id int) (*AwsProviderResourceAPIModel, er
 	}
 }
 
-func (v *vantageClient) DeleteAwsProvider(id int) error {
-	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%d", id))
+func (v *vantageClient) DeleteAwsProvider(id string) error {
+	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%s", id))
 	if err != nil {
 		return err
 	}

--- a/vantage/client.go
+++ b/vantage/client.go
@@ -87,7 +87,7 @@ func (v *vantageClient) AwsProviderInfo() (*AwsProviderInfoResult, error) {
 
 // AwsProviderResourceAPIModel describes the API data model.
 type AwsProviderResourceAPIModel struct {
-	Id              string    `json:"id"`
+	Id              string `json:"id"`
 	CrossAccountARN string `json:"cross_account_arn"`
 	BucketARN       string `json:"bucket_arn"`
 }
@@ -130,7 +130,7 @@ func (v *vantageClient) AddAwsProvider(in AwsProviderResourceAPIModel) (*AwsProv
 }
 
 func (v *vantageClient) UpdateAwsProvider(in AwsProviderResourceAPIModel) (*AwsProviderResourceAPIModel, error) {
-	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%d", in.Id))
+	uri, err := url.JoinPath(v.host, fmt.Sprintf("/v1/integrations/aws/%s", in.Id))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A general terraform best practice is to use a string for provider IDs.

While this isn't well documented, we see a lot of this when bridging Pulumi providers.

In order to create the Pulumi provider at https://github.com/lbrlabs/pulumi-vantage we need the provider ID to be a string.

I'm understanding of the lack of desire to change this, so I'm happy to maintain a fork if necessary, and this can be closed