### PR TITLE
fix(team_resource.go): fix to allow description to be empty

### DIFF
--- a/examples/resources/vantage_team/provider.tf
+++ b/examples/resources/vantage_team/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    vantage = {
+      source = "registry.terraform.io/vantage-sh/vantage"
+    }
+  }
+}

--- a/vantage/team_resource.go
+++ b/vantage/team_resource.go
@@ -2,7 +2,6 @@ package vantage
 
 import (
 	"context"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -44,6 +43,7 @@ func (r TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description of the team.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"workspace_tokens": schema.ListAttribute{
 				MarkdownDescription: "Workspace tokens to add the team to.",


### PR DESCRIPTION
This fix closes #21. Allows team description to be empty.