### PR TITLE
Validate workspace token attribute

### DIFF
--- a/docs/resources/cost_report.md
+++ b/docs/resources/cost_report.md
@@ -18,6 +18,9 @@ resource "vantage_cost_report" "demo_report" {
   folder_token        = "fldr_3555785cd0409118"
   filter              = "costs.provider = 'aws'"
   saved_filter_tokens = ["svd_fltr_e844a2ccace05933", "svd_fltr_1b4b80a380ef4ba2"]
+  workspace_token = "wrkspc_47c3254c790e9351"
+  # optionally, use folder_token instead of workspace_token
+  # folder_token = "fldr_47c3254c790e9351"
 }
 ```
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -17,6 +17,7 @@ resource "vantage_dashboard" "demo_dashboard" {
   widget_tokens = ["rprt_a2846903070824f4"]
   title         = "Demo Dashboard"
   date_interval = "last_month"
+  workspace_token = "wrkspc_47c3254c790e9351"
 }
 ```
 
@@ -27,6 +28,7 @@ resource "vantage_dashboard" "demo_dashboard" {
 
 - `title` (String) Title of the dashboard
 - `widget_tokens` (List of String) Tokens for widgets present in the dashboard. Currently only cost report tokens are supported.
+- `workspace_token` (String) The token for the Workspace the Dashboard is a part of.
 
 ### Optional
 
@@ -34,7 +36,6 @@ resource "vantage_dashboard" "demo_dashboard" {
 - `date_interval` (String) Determines the date range in the Dashboard. Guaranteed to be set to 'custom' if 'start_date' and 'end_date' are set.
 - `end_date` (String) The end date for the date range for CostReports in the Dashboard. ISO 8601 Formatted. Overwrites 'date_interval' if set.
 - `start_date` (String) The start date for the date range for CostReports in the Dashboard. ISO 8601 Formatted. Overwrites 'date_interval' if set.
-- `workspace_token` (String) The token for the Workspace the Dashboard is a part of.
 
 ### Read-Only
 

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -15,6 +15,13 @@ Manages a Folder.
 ```terraform
 resource "vantage_folder" "demo_folder" {
   title = "Demo Folder"
+
+  # Include either the parent_folder_token or workspace_token
+  # If both are included, the API will use the parent_folder_token
+
+  # Uncomment one of the following:
+  # parent_folder_token = "fldr_47c3254c790e9351"
+  workspace_token = "wrkspc_47c3254c790e9351"
 }
 ```
 

--- a/docs/resources/saved_filter.md
+++ b/docs/resources/saved_filter.md
@@ -25,11 +25,11 @@ resource "vantage_saved_filter" "demo_filter" {
 ### Required
 
 - `title` (String) Title of the Saved Filter
+- `workspace_token` (String) Workspace token to add the saved filter into.
 
 ### Optional
 
 - `filter` (String) VQL Query used for this saved filter.
-- `workspace_token` (String) Workspace token to add the saved filter into.
 
 ### Read-Only
 

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -19,6 +19,10 @@ resource "vantage_segment" "demo_segment" {
   priority = 50
   track_unallocated = false
   filter = "(costs.provider = 'aws' AND tags.name = NULL)"
+
+  # either provide workspace_token or parent_segment_token
+  workspace_token = "wrkspc_47c3254c790e9351"
+  # parent_segment_token = "fltr_sgmt_1e866feb74f0b1b4"
 }
 ```
 

--- a/examples/cost_report/main.tf
+++ b/examples/cost_report/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 resource "vantage_folder" "demo_folder" {
-  title = "Demo Folder"
+  title           = "Demo Folder"
   workspace_token = "wrkspc_47c3254c790e9351"
 }
 
@@ -17,8 +17,8 @@ resource "vantage_folder" "demo_folder_child" {
 }
 
 resource "vantage_saved_filter" "demo_filter" {
-  title  = "Demo Saved Filter"
-  filter = "(costs.provider = 'aws')"
+  title           = "Demo Saved Filter"
+  filter          = "(costs.provider = 'aws')"
   workspace_token = "wrkspc_47c3254c790e9351"
 }
 
@@ -29,25 +29,45 @@ resource "vantage_cost_report" "demo_report" {
   title               = "Demo Report"
 }
 resource "vantage_dashboard" "demo_dashboard" {
-  widget_tokens = [vantage_cost_report.demo_report.token]
-  title         = "Demo Dashboard"
-  date_interval = "last_month"
+  widget_tokens   = [vantage_cost_report.demo_report.token]
+  title           = "Demo Dashboard"
+  date_interval   = "last_month"
   workspace_token = "wrkspc_47c3254c790e9351"
 }
 
 resource "vantage_team" "demo_team" {
-  name = "Demo Team"
+  name        = "Demo Team"
   description = "Demo Team Description"
   user_emails = ["support@vantage.sh"]
 }
 
 resource "vantage_team" "demo_team_2" {
-  name = "Another Demo Team"
-  description = "Demo Team Description"
-  user_tokens = ["usr_36b848747e1683bc", "usr_899b013c355547db"]
+  name             = "Another Demo Team"
+  description      = "Demo Team Description"
+  user_tokens      = ["usr_36b848747e1683bc", "usr_899b013c355547db"]
   workspace_tokens = ["wrkspc_47c3254c790e9351"]
 }
 resource "vantage_access_grant" "demo_access_grant" {
-  team_token = vantage_team.demo_team.token
+  team_token     = vantage_team.demo_team.token
   resource_token = vantage_dashboard.demo_dashboard.token
 }
+
+# resource "vantage_cost_report" "demo_report2" {
+#   workspace_token     = "wrkspc_47c3254c790e9351"
+#   filter              = "costs.provider = 'kubernetes'"
+#   saved_filter_tokens = [vantage_saved_filter.demo_filter.token]
+#   title               = "Demo Report"
+# }
+
+resource "vantage_segment" "demo_segment" {
+  title = "Demo Segment"
+  description = "This is still a demo segment"
+  priority = 50
+  track_unallocated = false
+  filter = "(costs.provider = 'aws' AND tags.name = NULL)"
+
+  # either provide workspace_token or parent_segment_token
+  # workspace_token = "wrkspc_47c3254c790e9351"
+  parent_segment_token = "fltr_sgmt_1e866feb74f0b1b4"
+}
+

--- a/examples/cost_report/main.tf
+++ b/examples/cost_report/main.tf
@@ -8,6 +8,7 @@ terraform {
 
 resource "vantage_folder" "demo_folder" {
   title = "Demo Folder"
+  workspace_token = "wrkspc_47c3254c790e9351"
 }
 
 resource "vantage_folder" "demo_folder_child" {
@@ -31,6 +32,7 @@ resource "vantage_dashboard" "demo_dashboard" {
   widget_tokens = [vantage_cost_report.demo_report.token]
   title         = "Demo Dashboard"
   date_interval = "last_month"
+  workspace_token = "wrkspc_47c3254c790e9351"
 }
 
 resource "vantage_team" "demo_team" {
@@ -49,4 +51,3 @@ resource "vantage_access_grant" "demo_access_grant" {
   team_token = vantage_team.demo_team.token
   resource_token = vantage_dashboard.demo_dashboard.token
 }
-

--- a/examples/cost_report/main.tf
+++ b/examples/cost_report/main.tf
@@ -51,23 +51,3 @@ resource "vantage_access_grant" "demo_access_grant" {
   team_token     = vantage_team.demo_team.token
   resource_token = vantage_dashboard.demo_dashboard.token
 }
-
-# resource "vantage_cost_report" "demo_report2" {
-#   workspace_token     = "wrkspc_47c3254c790e9351"
-#   filter              = "costs.provider = 'kubernetes'"
-#   saved_filter_tokens = [vantage_saved_filter.demo_filter.token]
-#   title               = "Demo Report"
-# }
-
-resource "vantage_segment" "demo_segment" {
-  title = "Demo Segment"
-  description = "This is still a demo segment"
-  priority = 50
-  track_unallocated = false
-  filter = "(costs.provider = 'aws' AND tags.name = NULL)"
-
-  # either provide workspace_token or parent_segment_token
-  # workspace_token = "wrkspc_47c3254c790e9351"
-  parent_segment_token = "fltr_sgmt_1e866feb74f0b1b4"
-}
-

--- a/examples/resources/vantage_cost_report/resource.tf
+++ b/examples/resources/vantage_cost_report/resource.tf
@@ -3,4 +3,7 @@ resource "vantage_cost_report" "demo_report" {
   folder_token        = "fldr_3555785cd0409118"
   filter              = "costs.provider = 'aws'"
   saved_filter_tokens = ["svd_fltr_e844a2ccace05933", "svd_fltr_1b4b80a380ef4ba2"]
+  workspace_token = "wrkspc_47c3254c790e9351"
+  # optionally, use folder_token instead of workspace_token
+  # folder_token = "fldr_47c3254c790e9351"
 }

--- a/examples/resources/vantage_dashboard/resource.tf
+++ b/examples/resources/vantage_dashboard/resource.tf
@@ -2,4 +2,5 @@ resource "vantage_dashboard" "demo_dashboard" {
   widget_tokens = ["rprt_a2846903070824f4"]
   title         = "Demo Dashboard"
   date_interval = "last_month"
+  workspace_token = "wrkspc_47c3254c790e9351"
 }

--- a/examples/resources/vantage_folder/resource.tf
+++ b/examples/resources/vantage_folder/resource.tf
@@ -1,3 +1,10 @@
 resource "vantage_folder" "demo_folder" {
   title = "Demo Folder"
+
+  # Include either the parent_folder_token or workspace_token
+  # If both are included, the API will use the parent_folder_token
+
+  # Uncomment one of the following:
+  # parent_folder_token = "fldr_47c3254c790e9351" 
+  # workspace_token = "wrkspc_47c3254c790e9351"
 }

--- a/examples/resources/vantage_folder/resource.tf
+++ b/examples/resources/vantage_folder/resource.tf
@@ -5,6 +5,6 @@ resource "vantage_folder" "demo_folder" {
   # If both are included, the API will use the parent_folder_token
 
   # Uncomment one of the following:
-  # parent_folder_token = "fldr_47c3254c790e9351" 
-  # workspace_token = "wrkspc_47c3254c790e9351"
-}
+  workspace_token = "wrkspc_47c3254c790e9351"
+}# parent_folder_token = "fldr_47c3254c790e9351" 
+  

--- a/examples/resources/vantage_folder/resource.tf
+++ b/examples/resources/vantage_folder/resource.tf
@@ -5,6 +5,7 @@ resource "vantage_folder" "demo_folder" {
   # If both are included, the API will use the parent_folder_token
 
   # Uncomment one of the following:
+  # parent_folder_token = "fldr_47c3254c790e9351"
   workspace_token = "wrkspc_47c3254c790e9351"
-}# parent_folder_token = "fldr_47c3254c790e9351" 
+} 
   

--- a/examples/resources/vantage_segment/resource.tf
+++ b/examples/resources/vantage_segment/resource.tf
@@ -4,4 +4,8 @@ resource "vantage_segment" "demo_segment" {
   priority = 50
   track_unallocated = false
   filter = "(costs.provider = 'aws' AND tags.name = NULL)"
+
+  # either provide workspace_token or parent_segment_token
+  workspace_token = "wrkspc_47c3254c790e9351"
+  # parent_segment_token = "fltr_sgmt_1e866feb74f0b1b4"
 }

--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -3,6 +3,8 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -11,6 +13,8 @@ import (
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	costsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/costs"
 )
+
+var _ resource.ResourceWithConfigValidators = &CostReportResource{}
 
 type CostReportResource struct {
 	client *Client
@@ -227,4 +231,13 @@ func (r *CostReportResource) Configure(_ context.Context, req resource.Configure
 	}
 
 	r.client = req.ProviderData.(*Client)
+}
+
+func (r *CostReportResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.AtLeastOneOf(
+			path.MatchRoot("folder_token"),
+			path.MatchRoot("workspace_token"),
+		),
+	}
 }

--- a/vantage/dashboard_resource.go
+++ b/vantage/dashboard_resource.go
@@ -89,7 +89,6 @@ func (r DashboardResource) Schema(ctx context.Context, req resource.SchemaReques
 			"workspace_token": schema.StringAttribute{
 				MarkdownDescription: "The token for the Workspace the Dashboard is a part of.",
 				Required:            true,
-				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/vantage/dashboard_resource.go
+++ b/vantage/dashboard_resource.go
@@ -88,7 +88,7 @@ func (r DashboardResource) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"workspace_token": schema.StringAttribute{
 				MarkdownDescription: "The token for the Workspace the Dashboard is a part of.",
-				Optional:            true,
+				Required:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),

--- a/vantage/folder_resource.go
+++ b/vantage/folder_resource.go
@@ -3,6 +3,8 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -11,6 +13,8 @@ import (
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	foldersv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/folders"
 )
+
+var _ resource.ResourceWithConfigValidators = &FolderResource{}
 
 type FolderResource struct {
 	client *Client
@@ -173,4 +177,13 @@ func (r *FolderResource) Configure(_ context.Context, req resource.ConfigureRequ
 	}
 
 	r.client = req.ProviderData.(*Client)
+}
+
+func (r *FolderResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.AtLeastOneOf(
+			path.MatchRoot("parent_folder_token"),
+			path.MatchRoot("workspace_token"),
+		),
+	}
 }

--- a/vantage/saved_filter_resource.go
+++ b/vantage/saved_filter_resource.go
@@ -46,7 +46,6 @@ func (r SavedFilterResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"workspace_token": schema.StringAttribute{
 				MarkdownDescription: "Workspace token to add the saved filter into.",
 				Required:            true,
-				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/vantage/saved_filter_resource.go
+++ b/vantage/saved_filter_resource.go
@@ -45,7 +45,7 @@ func (r SavedFilterResource) Schema(ctx context.Context, req resource.SchemaRequ
 			},
 			"workspace_token": schema.StringAttribute{
 				MarkdownDescription: "Workspace token to add the saved filter into.",
-				Optional:            true,
+				Required:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),

--- a/vantage/segment_resource.go
+++ b/vantage/segment_resource.go
@@ -3,6 +3,8 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -13,6 +15,8 @@ import (
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	segmentsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/segments"
 )
+
+var _ resource.ResourceWithConfigValidators = &SegmentResource{}
 
 type SegmentResource struct {
 	client *Client
@@ -221,4 +225,13 @@ func (r *SegmentResource) Configure(_ context.Context, req resource.ConfigureReq
 	}
 
 	r.client = req.ProviderData.(*Client)
+}
+
+func (r *SegmentResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.AtLeastOneOf(
+			path.MatchRoot("workspace_token"),
+			path.MatchRoot("parent_segment_token"),
+		),
+	}
 }


### PR DESCRIPTION
Addresses https://github.com/vantage-sh/terraform-provider-vantage/issues/23

The immediate issue was bad documentation; the example should have included a `workspace_token` attribute. It now does (as do the examples for other resources).

That said, the issue got me thinking more about the our use of workspace tokens in the API. I've taken the step to make workspace token required for some resources, where before it was an optional parameter. It was optional before because _technically_ there are some access tokens that can intuit which workspace the resource should be assigned to; however, these tokens are not available for use with the Terraform provider, so I have decided that the workspace token should be present. In the case of folders, cost reports and segments, there is a choice of **either** workspace token or parent_folder_token, folder_token, or parent_segment_token, respectively.


cc @SebRosander 