### PR TITLE
Let groupings and filter be computed values according to the schema.

### DIFF
--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -53,10 +53,12 @@ func (r CostReportResource) Schema(ctx context.Context, req resource.SchemaReque
 			"filter": schema.StringAttribute{
 				MarkdownDescription: "Filter query to apply to the Cost Report",
 				Optional:            true,
+				Computed:            true,
 			},
 			"groupings": schema.StringAttribute{
 				MarkdownDescription: "Grouping aggregations applied to the filtered data.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"saved_filter_tokens": schema.ListAttribute{
 				ElementType:         types.StringType,


### PR DESCRIPTION
addresses #28 

This allows the provider to handle `groupings` and `filter` when the API return back a value such as the empty string, even though no value was passed in in the request. 

