### PR TITLE
feat: Expose report_token in the segments data source.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/vantage-sh/vantage-go v0.0.22
+	github.com/vantage-sh/vantage-go v0.0.24
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/vantage-sh/vantage-go v0.0.22 h1:hHuREZuxU/i2BKxbrX7Thbq7ByB5HLqAieyN5R0bZKg=
-github.com/vantage-sh/vantage-go v0.0.22/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
+github.com/vantage-sh/vantage-go v0.0.24 h1:8bKsbk2zofZ6CMVWfwSiY0ZjprZwbCDD/9Kbl9yY9T8=
+github.com/vantage-sh/vantage-go v0.0.24/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/vantage/datasource_business_metrics/business_metrics_data_source_gen.go
+++ b/vantage/datasource_business_metrics/business_metrics_data_source_gen.go
@@ -73,6 +73,11 @@ func BusinessMetricsDataSourceSchema(ctx context.Context) schema.Schema {
 										Description:         "The date of the Business Metric Value. ISO 8601 formatted.",
 										MarkdownDescription: "The date of the Business Metric Value. ISO 8601 formatted.",
 									},
+									"label": schema.StringAttribute{
+										Computed:            true,
+										Description:         "The label of the Business Metric Value.",
+										MarkdownDescription: "The label of the Business Metric Value.",
+									},
 								},
 								CustomType: ValuesType{
 									ObjectType: types.ObjectType{
@@ -81,8 +86,8 @@ func BusinessMetricsDataSourceSchema(ctx context.Context) schema.Schema {
 								},
 							},
 							Computed:            true,
-							Description:         "The dates and amounts for the BusinessMetric",
-							MarkdownDescription: "The dates and amounts for the BusinessMetric",
+							Description:         "The dates, amounts, and (optional) labels for the BusinessMetric.",
+							MarkdownDescription: "The dates, amounts, and (optional) labels for the BusinessMetric.",
 						},
 					},
 					CustomType: BusinessMetricsType{
@@ -1135,6 +1140,24 @@ func (t ValuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 			fmt.Sprintf(`date expected to be basetypes.StringValue, was: %T`, dateAttribute))
 	}
 
+	labelAttribute, ok := attributes["label"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label is missing from object`)
+
+		return nil, diags
+	}
+
+	labelVal, ok := labelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label expected to be basetypes.StringValue, was: %T`, labelAttribute))
+	}
+
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -1142,6 +1165,7 @@ func (t ValuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 	return ValuesValue{
 		Amount: amountVal,
 		Date:   dateVal,
+		Label:  labelVal,
 		state:  attr.ValueStateKnown,
 	}, diags
 }
@@ -1245,6 +1269,24 @@ func NewValuesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 			fmt.Sprintf(`date expected to be basetypes.StringValue, was: %T`, dateAttribute))
 	}
 
+	labelAttribute, ok := attributes["label"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label is missing from object`)
+
+		return NewValuesValueUnknown(), diags
+	}
+
+	labelVal, ok := labelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label expected to be basetypes.StringValue, was: %T`, labelAttribute))
+	}
+
 	if diags.HasError() {
 		return NewValuesValueUnknown(), diags
 	}
@@ -1252,6 +1294,7 @@ func NewValuesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 	return ValuesValue{
 		Amount: amountVal,
 		Date:   dateVal,
+		Label:  labelVal,
 		state:  attr.ValueStateKnown,
 	}, diags
 }
@@ -1326,23 +1369,25 @@ var _ basetypes.ObjectValuable = ValuesValue{}
 type ValuesValue struct {
 	Amount basetypes.StringValue `tfsdk:"amount"`
 	Date   basetypes.StringValue `tfsdk:"date"`
+	Label  basetypes.StringValue `tfsdk:"label"`
 	state  attr.ValueState
 }
 
 func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 2)
+	attrTypes := make(map[string]tftypes.Type, 3)
 
 	var val tftypes.Value
 	var err error
 
 	attrTypes["amount"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["date"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["label"] = basetypes.StringType{}.TerraformType(ctx)
 
 	objectType := tftypes.Object{AttributeTypes: attrTypes}
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 2)
+		vals := make(map[string]tftypes.Value, 3)
 
 		val, err = v.Amount.ToTerraformValue(ctx)
 
@@ -1359,6 +1404,14 @@ func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 		}
 
 		vals["date"] = val
+
+		val, err = v.Label.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["label"] = val
 
 		if err := tftypes.ValidateValue(objectType, vals); err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
@@ -1393,10 +1446,12 @@ func (v ValuesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		map[string]attr.Type{
 			"amount": basetypes.StringType{},
 			"date":   basetypes.StringType{},
+			"label":  basetypes.StringType{},
 		},
 		map[string]attr.Value{
 			"amount": v.Amount,
 			"date":   v.Date,
+			"label":  v.Label,
 		})
 
 	return objVal, diags
@@ -1425,6 +1480,10 @@ func (v ValuesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.Label.Equal(other.Label) {
+		return false
+	}
+
 	return true
 }
 
@@ -1440,5 +1499,6 @@ func (v ValuesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
 		"amount": basetypes.StringType{},
 		"date":   basetypes.StringType{},
+		"label":  basetypes.StringType{},
 	}
 }

--- a/vantage/resource_anomaly_notification/anomaly_notification_resource_gen.go
+++ b/vantage/resource_anomaly_notification/anomaly_notification_resource_gen.go
@@ -14,8 +14,8 @@ func AnomalyNotificationResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"cost_report_token": schema.StringAttribute{
 				Required:            true,
-				Description:         "The token of the Cost Report folder that has the notification.",
-				MarkdownDescription: "The token of the Cost Report folder that has the notification.",
+				Description:         "The token of the Cost Report that has the notification.",
+				MarkdownDescription: "The token of the Cost Report that has the notification.",
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
@@ -49,8 +49,8 @@ func AnomalyNotificationResourceSchema(ctx context.Context) schema.Schema {
 				ElementType:         types.StringType,
 				Optional:            true,
 				Computed:            true,
-				Description:         "The tokens of the users that receive the notification.",
-				MarkdownDescription: "The tokens of the users that receive the notification.",
+				Description:         "The tokens of the Users that receive the notification.",
+				MarkdownDescription: "The tokens of the Users that receive the notification.",
 			},
 		},
 	}

--- a/vantage/segments_data_source.go
+++ b/vantage/segments_data_source.go
@@ -112,6 +112,9 @@ func (d *segmentsDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 						"workspace_token": schema.StringAttribute{
 							Computed: true,
 						},
+						"report_token": schema.StringAttribute{
+							Computed: true,
+						},
 						"filter": schema.StringAttribute{
 							Computed: true,
 						},


### PR DESCRIPTION
Also verified in Terraform that you can pass a segment report token as the `cost_report_token` in a budget resource.