### PR TITLE
fix: Don't set dates when date interval is not custom.

### DIFF
--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -273,14 +273,20 @@ func (r CostReportResource) Update(ctx context.Context, req resource.UpdateReque
 		Filter:                  data.Filter.ValueString(),
 		SavedFilterTokens:       fromStringsValue(sft),
 		Groupings:               data.Groupings.ValueString(),
-		StartDate:               data.StartDate.ValueString(),
-		EndDate:                 data.EndDate.ValueString(),
 		PreviousPeriodStartDate: data.PreviousPeriodStartDate.ValueString(),
 		PreviousPeriodEndDate:   data.PreviousPeriodEndDate.ValueString(),
-		DateInterval:            data.DateInterval.ValueString(),
 		ChartType:               data.ChartType.ValueStringPointer(),
 		DateBin:                 data.DateBin.ValueStringPointer(),
 	}
+
+	if data.DateInterval.ValueString() == "custom" {
+		model.StartDate = data.StartDate.ValueString()
+		model.EndDate = data.EndDate.ValueString()
+		model.DateInterval = "custom"
+	} else {
+		model.DateInterval = data.DateInterval.ValueString()
+	}
+
 	params.WithUpdateCostReport(model)
 	out, err := r.client.V2.Costs.UpdateCostReport(params, r.client.Auth)
 	if err != nil {


### PR DESCRIPTION
Paired on this with @whereandy. 

**What does this fix?**
When trying to patch a cost report resource's `date_interval`, the `start_date` and `end_date` are being included because they are part of the TF state. This results in the API overwriting the provided `date_interval` field with the value `custom`. Incompatibility is mentioned in the [API docs](https://vantage.readme.io/reference/updatecostreport). 