### PR TITLE
Allow users to import resources.

### DIFF
--- a/vantage/access_grant_resource.go
+++ b/vantage/access_grant_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -12,6 +13,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	accessgrantsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/access_grants"
+)
+
+var (
+	_ resource.Resource                = (*AccessGrantResource)(nil)
+	_ resource.ResourceWithConfigure   = (*AccessGrantResource)(nil)
+	_ resource.ResourceWithImportState = (*AccessGrantResource)(nil)
 )
 
 type AccessGrantResource struct {
@@ -124,6 +131,10 @@ func (r AccessGrantResource) Read(ctx context.Context, req resource.ReadRequest,
 	state.Access = types.StringValue(out.Payload.Access)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r AccessGrantResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r AccessGrantResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/anomaly_notification_resource.go
+++ b/vantage/anomaly_notification_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -14,8 +15,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
-var _ resource.Resource = (*anomalyNotificationResource)(nil)
-var _ resource.ResourceWithConfigure = (*anomalyNotificationResource)(nil)
+var (
+	_ resource.Resource                = (*anomalyNotificationResource)(nil)
+	_ resource.ResourceWithConfigure   = (*anomalyNotificationResource)(nil)
+	_ resource.ResourceWithImportState = (*anomalyNotificationResource)(nil)
+)
 
 func NewAnomalyNotificationResource() resource.Resource {
 	return &anomalyNotificationResource{}
@@ -170,6 +174,10 @@ func (r *anomalyNotificationResource) Read(ctx context.Context, req resource.Rea
 	readPayloadIntoResourceModel(out.Payload, &data)
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *anomalyNotificationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r *anomalyNotificationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/billing_rule_resource.go
+++ b/vantage/billing_rule_resource.go
@@ -13,9 +13,12 @@ import (
 	billingrulesv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/billing_rules"
 )
 
-var _ resource.Resource = (*billingRuleResource)(nil)
-var _ resource.ResourceWithConfigure = (*billingRuleResource)(nil)
-var _ resource.ResourceWithValidateConfig = (*billingRuleResource)(nil)
+var (
+	_ resource.Resource                   = (*billingRuleResource)(nil)
+	_ resource.ResourceWithConfigure      = (*billingRuleResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*billingRuleResource)(nil)
+	_ resource.ResourceWithImportState    = (*billingRuleResource)(nil)
+)
 
 func NewBillingRuleResource() resource.Resource {
 	return &billingRuleResource{}
@@ -265,6 +268,10 @@ func (r *billingRuleResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *billingRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r *billingRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/budget_resource.go
+++ b/vantage/budget_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -13,8 +14,11 @@ import (
 	budgetsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/budgets"
 )
 
-var _ resource.Resource = (*budgetResource)(nil)
-var _ resource.ResourceWithConfigure = (*budgetResource)(nil)
+var (
+	_ resource.Resource                = (*budgetResource)(nil)
+	_ resource.ResourceWithConfigure   = (*budgetResource)(nil)
+	_ resource.ResourceWithImportState = (*budgetResource)(nil)
+)
 
 func NewBudgetResource() resource.Resource {
 	return &budgetResource{}
@@ -205,6 +209,10 @@ func (r *budgetResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *budgetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r *budgetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/business_metric_resource.go
+++ b/vantage/business_metric_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -16,8 +17,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = (*businessMetricResource)(nil)
-	_ resource.ResourceWithConfigure = (*businessMetricResource)(nil)
+	_ resource.Resource                = (*businessMetricResource)(nil)
+	_ resource.ResourceWithConfigure   = (*businessMetricResource)(nil)
+	_ resource.ResourceWithImportState = (*businessMetricResource)(nil)
 )
 
 func NewBusinessMetricResource() resource.Resource {
@@ -203,6 +205,10 @@ func (r *businessMetricResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *businessMetricResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r *businessMetricResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -14,7 +14,11 @@ import (
 	costsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/costs"
 )
 
-var _ resource.ResourceWithConfigValidators = &CostReportResource{}
+var (
+	_ resource.Resource                = (*CostReportResource)(nil)
+	_ resource.ResourceWithConfigure   = (*CostReportResource)(nil)
+	_ resource.ResourceWithImportState = (*CostReportResource)(nil)
+)
 
 type CostReportResource struct {
 	client *Client
@@ -239,6 +243,7 @@ func (r CostReportResource) Read(ctx context.Context, req resource.ReadRequest, 
 	state.ChartType = types.StringValue(out.Payload.ChartType)
 	state.DateBin = types.StringValue(out.Payload.DateBin)
 	state.WorkspaceToken = types.StringValue(out.Payload.WorkspaceToken)
+	state.FolderToken = types.StringValue(out.Payload.FolderToken)
 	savedFilterTokensValue, diag := types.ListValueFrom(ctx, types.StringType, out.Payload.SavedFilterTokens)
 	if diag.HasError() {
 		resp.Diagnostics.Append(diag...)
@@ -247,6 +252,10 @@ func (r CostReportResource) Read(ctx context.Context, req resource.ReadRequest, 
 	state.SavedFilterTokens = savedFilterTokensValue
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r CostReportResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r CostReportResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/dashboard_resource.go
+++ b/vantage/dashboard_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -10,6 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	dashboardsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/dashboards"
+)
+
+var (
+	_ resource.Resource                = (*DashboardResource)(nil)
+	_ resource.ResourceWithConfigure   = (*DashboardResource)(nil)
+	_ resource.ResourceWithImportState = (*DashboardResource)(nil)
 )
 
 type DashboardResource struct {
@@ -204,6 +211,10 @@ func (r DashboardResource) Read(ctx context.Context, req resource.ReadRequest, r
 	state.SavedFilterTokens = saved_filters
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r DashboardResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r DashboardResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/folder_resource.go
+++ b/vantage/folder_resource.go
@@ -14,7 +14,11 @@ import (
 	foldersv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/folders"
 )
 
-var _ resource.ResourceWithConfigValidators = &FolderResource{}
+var (
+	_ resource.Resource                = (*FolderResource)(nil)
+	_ resource.ResourceWithConfigure   = (*FolderResource)(nil)
+	_ resource.ResourceWithImportState = (*FolderResource)(nil)
+)
 
 type FolderResource struct {
 	client *Client
@@ -125,6 +129,10 @@ func (r FolderResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.Title = types.StringValue(out.Payload.Title)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r FolderResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r FolderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/managed_account_resource.go
+++ b/vantage/managed_account_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -13,8 +14,11 @@ import (
 	managedaccountsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/managed_accounts"
 )
 
-var _ resource.Resource = (*managedAccountResource)(nil)
-var _ resource.ResourceWithConfigure = (*managedAccountResource)(nil)
+var (
+	_ resource.Resource                = (*managedAccountResource)(nil)
+	_ resource.ResourceWithConfigure   = (*managedAccountResource)(nil)
+	_ resource.ResourceWithImportState = (*managedAccountResource)(nil)
+)
 
 func NewManagedAccountResource() resource.Resource {
 	return &managedAccountResource{}
@@ -144,6 +148,10 @@ func (r *managedAccountResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *managedAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r *managedAccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/report_notification_resource.go
+++ b/vantage/report_notification_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -11,6 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	notifsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/report_notifications"
+)
+
+var (
+	_ resource.Resource                = (*ReportNotificationResource)(nil)
+	_ resource.ResourceWithConfigure   = (*ReportNotificationResource)(nil)
+	_ resource.ResourceWithImportState = (*ReportNotificationResource)(nil)
 )
 
 type ReportNotificationResource struct {
@@ -172,6 +179,10 @@ func (r *ReportNotificationResource) Read(ctx context.Context, req resource.Read
 	state.Frequency = types.StringValue(out.Payload.Frequency)
 	state.Change = types.StringValue(out.Payload.Change)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *ReportNotificationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r *ReportNotificationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/saved_filter_resource.go
+++ b/vantage/saved_filter_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -10,6 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	filtersv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/saved_filters"
+)
+
+var (
+	_ resource.Resource                = (*SavedFilterResource)(nil)
+	_ resource.ResourceWithConfigure   = (*SavedFilterResource)(nil)
+	_ resource.ResourceWithImportState = (*SavedFilterResource)(nil)
 )
 
 type SavedFilterResource struct {
@@ -118,6 +125,10 @@ func (r SavedFilterResource) Read(ctx context.Context, req resource.ReadRequest,
 	state.WorkspaceToken = types.StringValue(out.Payload.WorkspaceToken)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r SavedFilterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r SavedFilterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/segment_resource.go
+++ b/vantage/segment_resource.go
@@ -16,7 +16,11 @@ import (
 	segmentsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/segments"
 )
 
-var _ resource.ResourceWithConfigValidators = &SegmentResource{}
+var (
+	_ resource.Resource                = (*SegmentResource)(nil)
+	_ resource.ResourceWithConfigure   = (*SegmentResource)(nil)
+	_ resource.ResourceWithImportState = (*SegmentResource)(nil)
+)
 
 type SegmentResource struct {
 	client *Client
@@ -175,6 +179,10 @@ func (r SegmentResource) Read(ctx context.Context, req resource.ReadRequest, res
 	state.TrackUnallocated = types.BoolValue(out.Payload.TrackUnallocated)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r SegmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r SegmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/team_resource.go
+++ b/vantage/team_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -11,6 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 	teamsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/teams"
+)
+
+var (
+	_ resource.Resource                = (*TeamResource)(nil)
+	_ resource.ResourceWithConfigure   = (*TeamResource)(nil)
+	_ resource.ResourceWithImportState = (*TeamResource)(nil)
 )
 
 type TeamResource struct {
@@ -236,6 +243,10 @@ func (r TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	state.WorkspaceTokens = workspaceTokensValue
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r TeamResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r TeamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/vantage/virtual_tag_config_resource.go
+++ b/vantage/virtual_tag_config_resource.go
@@ -3,6 +3,7 @@ package vantage
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -12,8 +13,11 @@ import (
 	tagsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/virtual_tags"
 )
 
-var _ resource.Resource = (*VirtualTagConfigResource)(nil)
-var _ resource.ResourceWithConfigure = (*VirtualTagConfigResource)(nil)
+var (
+	_ resource.Resource                = (*VirtualTagConfigResource)(nil)
+	_ resource.ResourceWithConfigure   = (*VirtualTagConfigResource)(nil)
+	_ resource.ResourceWithImportState = (*VirtualTagConfigResource)(nil)
+)
 
 type VirtualTagConfigResource struct {
 	client *Client
@@ -193,6 +197,10 @@ func (r VirtualTagConfigResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r VirtualTagConfigResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("token"), req, resp)
 }
 
 func (r VirtualTagConfigResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {


### PR DESCRIPTION
Also did a little housekeeping, adding interface checks for all the resources and made them all the same format (that which was present in [the tf docs](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-resource-import) for consistency).


An example:
1. Previously created resource to show expected state.
2. Remove from TF state so it no longer knows about it.
3. `terraform plan` to show the create action for the "new" resource.
4. `terraform import` using the token.
5. `terraform plan` showing the imported resource means state reflects expectation and no action required.
```
➜  terraform state show vantage_cost_report.demo_report
# vantage_cost_report.demo_report:
resource "vantage_cost_report" "demo_report" {
    chart_type          = "line"
    date_bin            = "cumulative"
    date_interval       = "this_month"
    end_date            = "2024-10-31"
    filter              = "(costs.provider = 'kubernetes')"
    saved_filter_tokens = [
        "svd_fltr_1b4b80a380ef4ba2",
    ]
    start_date          = "2024-10-01"
    title               = "Demo Report"
    token               = "rprt_7acf44785c4c4a99"
    workspace_token     = "wrkspc_a609c8b9be478760"
}
➜  terraform state rm vantage_cost_report.demo_report
Removed vantage_cost_report.demo_report
Successfully removed 1 resource instance(s).
➜  terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - vantage-sh/vantage in /Users/mac/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
vantage_saved_filter.demo_filter: Refreshing state...
vantage_folder.demo_folder: Refreshing state...
vantage_folder.demo_folder_child: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vantage_cost_report.demo_report will be created
  + resource "vantage_cost_report" "demo_report" {
      + chart_type                 = "line"
      + date_bin                   = "cumulative"
      + date_interval              = "this_month"
      + end_date                   = (known after apply)
      + filter                     = "(costs.provider = 'kubernetes')"
      + folder_token               = "fldr_55856114eb438f43"
      + groupings                  = (known after apply)
      + previous_period_end_date   = (known after apply)
      + previous_period_start_date = (known after apply)
      + saved_filter_tokens        = [
          + "svd_fltr_1b4b80a380ef4ba2",
        ]
      + start_date                 = (known after apply)
      + title                      = "Demo Report"
      + token                      = (known after apply)
      + workspace_token            = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
➜ terraform import vantage_cost_report.demo_report rprt_7acf44785c4c4a99
vantage_cost_report.demo_report: Importing from ID "rprt_7acf44785c4c4a99"...
vantage_cost_report.demo_report: Import prepared!
  Prepared vantage_cost_report for import
vantage_cost_report.demo_report: Refreshing state...

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

➜ terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - vantage-sh/vantage in /Users/mac/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
vantage_folder.demo_folder: Refreshing state...
vantage_saved_filter.demo_filter: Refreshing state...
vantage_folder.demo_folder_child: Refreshing state...
vantage_cost_report.demo_report: Refreshing state...

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

```