### PR TITLE
ignore include_performance when generating the BudgetModel

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -56,6 +56,8 @@ resources:
       path: /budgets/{budget_token}
       method: DELETE
     schema:
+      ignores:
+        - include_performance
       attributes:
         overrides:
           token:

--- a/vantage/resource_budget/budget_resource_gen.go
+++ b/vantage/resource_budget/budget_resource_gen.go
@@ -40,12 +40,6 @@ func BudgetResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The token of the Creator of the Budget.",
 				MarkdownDescription: "The token of the Creator of the Budget.",
 			},
-			"include_performance": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				Description:         "Include performance data.",
-				MarkdownDescription: "Include performance data.",
-			},
 			"name": schema.StringAttribute{
 				Required:            true,
 				Description:         "The name of the Budget.",
@@ -132,17 +126,16 @@ func BudgetResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type BudgetModel struct {
-	BudgetAlertTokens  types.List   `tfsdk:"budget_alert_tokens"`
-	CostReportToken    types.String `tfsdk:"cost_report_token"`
-	CreatedAt          types.String `tfsdk:"created_at"`
-	CreatedByToken     types.String `tfsdk:"created_by_token"`
-	IncludePerformance types.Bool   `tfsdk:"include_performance"`
-	Name               types.String `tfsdk:"name"`
-	Performance        types.List   `tfsdk:"performance"`
-	Periods            types.List   `tfsdk:"periods"`
-	Token              types.String `tfsdk:"token"`
-	UserToken          types.String `tfsdk:"user_token"`
-	WorkspaceToken     types.String `tfsdk:"workspace_token"`
+	BudgetAlertTokens types.List   `tfsdk:"budget_alert_tokens"`
+	CostReportToken   types.String `tfsdk:"cost_report_token"`
+	CreatedAt         types.String `tfsdk:"created_at"`
+	CreatedByToken    types.String `tfsdk:"created_by_token"`
+	Name              types.String `tfsdk:"name"`
+	Performance       types.List   `tfsdk:"performance"`
+	Periods           types.List   `tfsdk:"periods"`
+	Token             types.String `tfsdk:"token"`
+	UserToken         types.String `tfsdk:"user_token"`
+	WorkspaceToken    types.String `tfsdk:"workspace_token"`
 }
 
 var _ basetypes.ObjectTypable = PerformanceType{}


### PR DESCRIPTION
`include_performance` is a parameter you can use when getting budgets that for some reason got added as an attribute to the budget model by `tfplugingen-openapi generate`. This explicitly omits that attribute during generation.