### PR TITLE
fix: Dont use the resource model struct for the data source.

### DIFF
--- a/vantage/budget_resource_model.go
+++ b/vantage/budget_resource_model.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	resource_budget "github.com/vantage-sh/terraform-provider-vantage/vantage/resource_budget"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 )
@@ -41,11 +40,11 @@ func toCreateModel(ctx context.Context, diags *diag.Diagnostics, src budgetModel
 		WorkspaceToken:  src.WorkspaceToken.ValueString(),
 	}
 
-    if !src.ChildBudgetTokens.IsNull() && !src.ChildBudgetTokens.IsUnknown() {
-        childBudgetTokens := []string{}
-        src.ChildBudgetTokens.ElementsAs(ctx, &childBudgetTokens, false)
-        dst.ChildBudgetTokens = childBudgetTokens
-    }
+	if !src.ChildBudgetTokens.IsNull() && !src.ChildBudgetTokens.IsUnknown() {
+		childBudgetTokens := []string{}
+		src.ChildBudgetTokens.ElementsAs(ctx, &childBudgetTokens, false)
+		dst.ChildBudgetTokens = childBudgetTokens
+	}
 
 	if !src.Periods.IsNull() && !src.Periods.IsUnknown() {
 		periods := make([]*budgetPeriodResourceModel, 0, len(src.Periods.Elements()))
@@ -159,13 +158,13 @@ func applyBudgetPayload(ctx context.Context, isDataSource bool, src *modelsv2.Bu
 		dst.BudgetAlertTokens = budgetAlertTokens
 	}
 
-    if src.ChildBudgetTokens != nil {
-        childBudgetTokens, diag := types.ListValueFrom(ctx, types.StringType, src.ChildBudgetTokens)
-        if diag.HasError() {
-            return diag
-        }
-        dst.ChildBudgetTokens = childBudgetTokens
-    }
+	if src.ChildBudgetTokens != nil {
+		childBudgetTokens, diag := types.ListValueFrom(ctx, types.StringType, src.ChildBudgetTokens)
+		if diag.HasError() {
+			return diag
+		}
+		dst.ChildBudgetTokens = childBudgetTokens
+	}
 
 	if src.Performance != nil {
 		perfs := make([]budgetPerformanceModel, 0, len(src.Performance))
@@ -238,7 +237,6 @@ func applyBudgetPayload(ctx context.Context, isDataSource bool, src *modelsv2.Bu
 				"end_at":   types.StringType,
 				"start_at": types.StringType,
 			}
-			tflog.Debug(ctx, fmt.Sprintf("andy 2 isDataSource: %v, periods %v, attrTypes %v", isDataSource, periods, attrTypes))
 			l, d := types.ListValueFrom(
 				ctx,
 				types.ObjectType{AttrTypes: attrTypes},

--- a/vantage/kubernetes_efficiency_report_resource_test.go
+++ b/vantage/kubernetes_efficiency_report_resource_test.go
@@ -50,7 +50,7 @@ resource "vantage_kubernetes_efficiency_report" "kubernetes_efficiency_report" {
 	date_interval = "custom"
 	start_date = "2024-01-01"
 	end_date = "2024-01-31"
-	groupings = ["cluster_id"]
+	groupings = ["namespace","label:app"]
 }
 `, title, filter)
 }

--- a/vantage/kubernetes_efficiency_reports_data_source.go
+++ b/vantage/kubernetes_efficiency_reports_data_source.go
@@ -2,7 +2,6 @@ package vantage
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -31,23 +30,24 @@ func (d *kubernetesEfficiencyReportsDataSource) Configure(ctx context.Context, r
 }
 
 type kubernetesEfficiencyReportsDataSourceModel struct {
-	KubernetesEfficiencyReports []kubernetesEfficiencyReportModel `tfsdk:"kubernetes_efficiency_reports"`
+	KubernetesEfficiencyReports []kubernetesEfficiencyReportDataModel `tfsdk:"kubernetes_efficiency_reports"`
 }
 
-// type kubernetesEfficiencyReportModel struct {
-// 	AggregatedBy   types.String `tfsdk:"aggregated_by"`
-// 	CreatedAt      types.String `tfsdk:"created_at"`
-// 	DateBucket     types.String `tfsdk:"date_bucket"`
-// 	DateInterval   types.String `tfsdk:"date_interval"`
-// 	Default        types.Bool   `tfsdk:"default"`
-// 	EndDate        types.String `tfsdk:"end_date"`
-// 	Groupings      types.String `tfsdk:"groupings"`
-// 	StartDate      types.String `tfsdk:"start_date"`
-// 	Title          types.String `tfsdk:"title"`
-// 	Token          types.String `tfsdk:"token"`
-// 	UserToken      types.String `tfsdk:"user_token"`
-// 	WorkspaceToken types.String `tfsdk:"workspace_token"`
-// }
+type kubernetesEfficiencyReportDataModel struct {
+	AggregatedBy   types.String `tfsdk:"aggregated_by"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	DateBucket     types.String `tfsdk:"date_bucket"`
+	DateInterval   types.String `tfsdk:"date_interval"`
+	Default        types.Bool   `tfsdk:"default"`
+	EndDate        types.String `tfsdk:"end_date"`
+	Filter         types.String `tfsdk:"filter"`
+	Groupings      types.String `tfsdk:"groupings"`
+	StartDate      types.String `tfsdk:"start_date"`
+	Title          types.String `tfsdk:"title"`
+	Token          types.String `tfsdk:"token"`
+	UserToken      types.String `tfsdk:"user_token"`
+	WorkspaceToken types.String `tfsdk:"workspace_token"`
+}
 
 func (d *kubernetesEfficiencyReportsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_kubernetes_efficiency_reports"
@@ -76,22 +76,16 @@ func (d *kubernetesEfficiencyReportsDataSource) Read(ctx context.Context, req da
 		return
 	}
 
-	reports := []kubernetesEfficiencyReportModel{}
+	reports := []kubernetesEfficiencyReportDataModel{}
 	for _, ker := range out.Payload.KubernetesEfficiencyReports {
-		splitGroupings := strings.Split(ker.Groupings, ",")
-		groupings, diag := types.ListValueFrom(ctx, types.StringType, splitGroupings)
-		if diag.HasError() {
-			resp.Diagnostics.Append(diag...)
-			return
-		}
-		report := kubernetesEfficiencyReportModel{
+		report := kubernetesEfficiencyReportDataModel{
 			AggregatedBy:   types.StringValue(ker.AggregatedBy),
 			CreatedAt:      types.StringValue(ker.CreatedAt),
 			DateBucket:     types.StringValue(ker.DateBucket),
 			DateInterval:   types.StringValue(ker.DateInterval),
 			Default:        types.BoolValue(ker.Default),
 			EndDate:        types.StringValue(ker.EndDate),
-			Groupings:      groupings,
+			Groupings:      types.StringValue(ker.Groupings),
 			StartDate:      types.StringValue(ker.StartDate),
 			Title:          types.StringValue(ker.Title),
 			Token:          types.StringValue(ker.Token),

--- a/vantage/kubernetes_efficiency_reports_data_source_test.go
+++ b/vantage/kubernetes_efficiency_reports_data_source_test.go
@@ -1,0 +1,51 @@
+package vantage
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vantage-sh/terraform-provider-vantage/vantage/acctest"
+)
+
+func TestAccKubernetesEfficiencyReportsDataSource_basic(t *testing.T) {
+	resourceName := "data.vantage_kubernetes_efficiency_reports.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExampleKubernetesReportsDataSourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVantageCheckKReportsExist(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccVantageCheckKReportsExist(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		reports, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		numReports, err := strconv.Atoi(reports.Primary.Attributes["kubernetes_efficiency_reports.#"])
+		if err != nil {
+			return err
+		}
+
+		if numReports > 0 {
+			return nil
+		}
+
+		return fmt.Errorf("Reports not found")
+	}
+}
+
+const testAccExampleKubernetesReportsDataSourceConfig = `
+data "vantage_kubernetes_efficiency_reports" "test" {}
+`


### PR DESCRIPTION
TakeTwo was seeing this:
```
Error: List Type Validation Error

  with data.vantage_kubernetes_efficiency_reports.all,
An unexpected error was encountered trying to validate an attribute value.
This is always an error in the provider. Please report the following to the
provider developer:

expected List value, received tftypes.Value with value:
tftypes.String<"cluster_id">
```
when trying to apply this TF:
```
data "vantage_kubernetes_efficiency_reports" "all" {}
```

I tracked it down to the fact that I was using the resource struct to hold the attributes for the data source. This was an error because groupings in the resource assumes it is a list, but the data source requires it to be a string. So, they are not interchangeable.

In addition, this error did not show up earlier because of lack of test coverage on data sources.
