### PR TITLE
Business Metrics resource change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/vantage-sh/vantage-go v0.0.51
 )
 
-// replace github.com/vantage-sh/vantage-go v0.0.46 => ../vantage-go
+replace github.com/vantage-sh/vantage-go v0.0.51 => ../vantage-go
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/vantage-sh/vantage-go v0.0.51
+	github.com/vantage-sh/vantage-go v0.0.52
 )
 
-replace github.com/vantage-sh/vantage-go v0.0.51 => ../vantage-go
+// replace github.com/vantage-sh/vantage-go v0.0.51 => ../vantage-go
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/vantage-sh/vantage-go v0.0.52
 )
 
-// replace github.com/vantage-sh/vantage-go v0.0.51 => ../vantage-go
+// replace github.com/vantage-sh/vantage-go => ../vantage-go
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/vantage-sh/vantage-go v0.0.52 h1:0M82JQAT4zwtVd37wzeE24/oouEWNPpyUXnpotPmqGM=
+github.com/vantage-sh/vantage-go v0.0.52/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/vantage-sh/vantage-go v0.0.51 h1:OjwU5qnlv0N1Kg/dkh5ODhwbOGjkgbu0bk1sMMbKV1s=
-github.com/vantage-sh/vantage-go v0.0.51/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/vantage/business_metric_resource.go
+++ b/vantage/business_metric_resource.go
@@ -3,16 +3,13 @@ package vantage
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/vantage-sh/terraform-provider-vantage/vantage/resource_business_metric"
 	businessmetricsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/business_metrics"
@@ -46,101 +43,16 @@ func (r *businessMetricResource) Metadata(ctx context.Context, req resource.Meta
 }
 
 func (r *businessMetricResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	// resp.Schema = resource_business_metric.BusinessMetricResourceSchema(ctx)
-	resp.Schema = schema.Schema{
-		Attributes: map[string]schema.Attribute{
-			"cost_report_tokens_with_metadata": schema.ListNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"cost_report_token": schema.StringAttribute{
-							Required:            true,
-							Description:         "The token of the CostReport the BusinessMetric is attached to.",
-							MarkdownDescription: "The token of the CostReport the BusinessMetric is attached to.",
-						},
-						"label_filter": schema.ListAttribute{
-							ElementType:         types.StringType,
-							Computed:            true,
-							Description:         "The labels that the BusinessMetric is filtered by within a particular CostReport.",
-							MarkdownDescription: "The labels that the BusinessMetric is filtered by within a particular CostReport.",
-						},
-						"unit_scale": schema.StringAttribute{
-							Optional:            true,
-							Computed:            true,
-							Description:         "Determines the scale of the BusinessMetric's values within the CostReport.",
-							MarkdownDescription: "Determines the scale of the BusinessMetric's values within the CostReport.",
-							Validators: []validator.String{
-								stringvalidator.OneOf(
-									"per_unit",
-									"per_hundred",
-									"per_thousand",
-									"per_million",
-									"per_billion",
-								),
-							},
-							Default: stringdefault.StaticString("per_unit"),
-						},
-					},
-					CustomType: resource_business_metric.CostReportTokensWithMetadataType{
-						ObjectType: types.ObjectType{
-							AttrTypes: resource_business_metric.CostReportTokensWithMetadataValue{}.AttributeTypes(ctx),
-						},
-					},
-				},
-				Optional:            true,
-				Computed:            true,
-				Description:         "The tokens for any CostReports that use the BusinessMetric, and the unit scale.",
-				MarkdownDescription: "The tokens for any CostReports that use the BusinessMetric, and the unit scale.",
-			},
-			"created_by_token": schema.StringAttribute{
-				Computed:            true,
-				Description:         "The token of the User who created the BusinessMetric.",
-				MarkdownDescription: "The token of the User who created the BusinessMetric.",
-			},
-			"title": schema.StringAttribute{
-				Required:            true,
-				Description:         "The title of the BusinessMetrics.",
-				MarkdownDescription: "The title of the BusinessMetrics.",
-			},
-			"token": schema.StringAttribute{
-				Computed:            true,
-				Description:         "The token of the business metric",
-				MarkdownDescription: "The token of the business metric",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"values": schema.ListNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"amount": schema.Float64Attribute{
-							Required: true,
-						},
-						"date": schema.StringAttribute{
-							Required:            true,
-							Description:         "The date of the Business Metric Value. ISO 8601 formatted.",
-							MarkdownDescription: "The date of the Business Metric Value. ISO 8601 formatted.",
-						},
-						"label": schema.StringAttribute{
-							Optional:            true,
-							Computed:            true,
-							Description:         "The label of the Business Metric Value.",
-							MarkdownDescription: "The label of the Business Metric Value.",
-						},
-					},
-					CustomType: resource_business_metric.ValuesType{
-						ObjectType: types.ObjectType{
-							AttrTypes: resource_business_metric.ValuesValue{}.AttributeTypes(ctx),
-						},
-					},
-				},
-				Optional:            true,
-				Computed:            true,
-				Description:         "The dates and amounts for the BusinessMetric.",
-				MarkdownDescription: "The dates and amounts for the BusinessMetric.",
-			},
+	s := resource_business_metric.BusinessMetricResourceSchema(ctx)
+	attrs := s.GetAttributes()
+	s.Attributes["token"] = schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: attrs["token"].GetMarkdownDescription(),
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
 		},
 	}
-
+	resp.Schema = s
 }
 
 func (r *businessMetricResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/vantage/business_metric_resource.go
+++ b/vantage/business_metric_resource.go
@@ -2,7 +2,6 @@ package vantage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -15,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/vantage-sh/terraform-provider-vantage/vantage/resource_business_metric"
 	businessmetricsv2 "github.com/vantage-sh/vantage-go/vantagev2/vantage/business_metrics"
 )
@@ -269,7 +267,6 @@ func (r *businessMetricResource) Update(ctx context.Context, req resource.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("ANDY UPDATE"))
 
 	oldValues := data.Values
 

--- a/vantage/business_metric_resource_test.go
+++ b/vantage/business_metric_resource_test.go
@@ -35,26 +35,43 @@ func TestAccBusinessMetric_basic(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			{ // create without values
-				Config: testAccVantageBusinessMetricTf_basic("test-no-values", "test", ""),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("vantage_business_metric.test-no-values", "token"),
-					resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "title", "test"),
-					resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "values.#", "0"),
-				),
-			},
-			{ // update without values
-				Config: testAccVantageBusinessMetricTf_basic("test-no-values", "updated-test", ""),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("vantage_business_metric.test-no-values", "token"),
-					resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "title", "updated-test"),
-					resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "values.#", "0"),
-				),
-			},
-			{ // create with values
+			// { // create without values
+			// 	Config: testAccVantageBusinessMetricTf_basic("test-no-values", "test", ""),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		resource.TestCheckResourceAttrSet("vantage_business_metric.test-no-values", "token"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "title", "test"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "values.#", "0"),
+			// 	),
+			// },
+			// { // update without values
+			// 	Config: testAccVantageBusinessMetricTf_basic("test-no-values", "updated-test", ""),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		resource.TestCheckResourceAttrSet("vantage_business_metric.test-no-values", "token"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "title", "updated-test"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "values.#", "0"),
+			// 	),
+			// },
+			// { // create with values
+			// 	Config: testAccVantageBusinessMetricTf_basic("test", "test", tfValues([]map[string]string{
+			// 		{"date": date1, "amount": "345.12"},
+			// 		{"date": date2, "amount": "123.45", "label": "a-label"},
+			// 	})),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		resource.TestCheckResourceAttrSet("vantage_business_metric.test", "token"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test", "title", "test"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.date", date1),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.amount", "345.12"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.label", ""),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.date", date2),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.amount", "123.45"),
+			// 		resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.label", "a-label"),
+			// 	),
+			// },
+			{ // update values
 				Config: testAccVantageBusinessMetricTf_basic("test", "test", tfValues([]map[string]string{
 					{"date": date1, "amount": "345.12"},
 					{"date": date2, "amount": "123.45", "label": "a-label"},
+					{"date": date3, "amount": "123.45", "label": "a-label"},
 				})),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vantage_business_metric.test", "token"),
@@ -65,17 +82,20 @@ func TestAccBusinessMetric_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.date", date2),
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.amount", "123.45"),
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.label", "a-label"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.2.date", date3),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.2.amount", "123.45"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.2.label", "a-label"),
 				),
 			},
-			{ // update values
-				Config: testAccVantageBusinessMetricTf_basic("test", "test", tfValues([]map[string]string{
+			{ // update the resource, but dont touch the values
+				Config: testAccVantageBusinessMetricTf_basic("test", "updated-test", tfValues([]map[string]string{
 					{"date": date1, "amount": "345.12"},
 					{"date": date2, "amount": "123.45", "label": "a-label"},
 					{"date": date3, "amount": "123.45", "label": "a-label"},
 				})),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vantage_business_metric.test", "token"),
-					resource.TestCheckResourceAttr("vantage_business_metric.test", "title", "test"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "title", "updated-test"),
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.date", date1),
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.amount", "345.12"),
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.label", ""),

--- a/vantage/business_metric_resource_test.go
+++ b/vantage/business_metric_resource_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestAccBusinessMetric_basic(t *testing.T) {
 	now := time.Now()
-	date1 := fmt.Sprintf("%d-01-10", now.Year())
-	date2 := fmt.Sprintf("%d-01-01", now.Year())
+	date1 := fmt.Sprintf("%d-03-01", now.Year())
+	date2 := fmt.Sprintf("%d-02-01", now.Year())
+	date3 := fmt.Sprintf("%d-01-01", now.Year())
 	tfValues := func(values []map[string]string) string {
 		if values == nil {
 			return ""
@@ -42,6 +43,14 @@ func TestAccBusinessMetric_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "values.#", "0"),
 				),
 			},
+			{ // update without values
+				Config: testAccVantageBusinessMetricTf_basic("test-no-values", "updated-test", ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vantage_business_metric.test-no-values", "token"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "title", "updated-test"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test-no-values", "values.#", "0"),
+				),
+			},
 			{ // create with values
 				Config: testAccVantageBusinessMetricTf_basic("test", "test", tfValues([]map[string]string{
 					{"date": date1, "amount": "345.12"},
@@ -56,6 +65,26 @@ func TestAccBusinessMetric_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.date", date2),
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.amount", "123.45"),
 					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.label", "a-label"),
+				),
+			},
+			{ // update values
+				Config: testAccVantageBusinessMetricTf_basic("test", "test", tfValues([]map[string]string{
+					{"date": date1, "amount": "345.12"},
+					{"date": date2, "amount": "123.45", "label": "a-label"},
+					{"date": date3, "amount": "123.45", "label": "a-label"},
+				})),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vantage_business_metric.test", "token"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "title", "test"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.date", date1),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.amount", "345.12"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.0.label", ""),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.date", date2),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.amount", "123.45"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.1.label", "a-label"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.2.date", date3),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.2.amount", "123.45"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test", "values.2.label", "a-label"),
 				),
 			},
 		},

--- a/vantage/business_metrics_data_source.go
+++ b/vantage/business_metrics_data_source.go
@@ -29,8 +29,10 @@ func (r *businessMetricsDataSource) Configure(_ context.Context, req datasource.
 }
 
 type businessMetricsDataSourceModel struct {
-	BusinessMetrics []businessMetricResourceModel `tfsdk:"business_metrics"`
+	BusinessMetrics []businessMetricDataSourceValue `tfsdk:"business_metrics"`
 }
+
+// type businessMetricsDataSourceModel datasource_business_metrics.BusinessMetricsModel
 
 func (d *businessMetricsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_business_metrics"
@@ -61,10 +63,10 @@ func (d *businessMetricsDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	metrics := []businessMetricResourceModel{}
+	metrics := []businessMetricDataSourceValue{}
 	for _, metric := range out.Payload.BusinessMetrics {
-		model := businessMetricResourceModel{}
-		diag := model.applyPayload(ctx, metric, true)
+		model := businessMetricDataSourceValue{}
+		diag := model.applyPayload(ctx, metric)
 		if diag.HasError() {
 			resp.Diagnostics.Append(diag...)
 			return

--- a/vantage/business_metrics_data_source.go
+++ b/vantage/business_metrics_data_source.go
@@ -32,8 +32,6 @@ type businessMetricsDataSourceModel struct {
 	BusinessMetrics []businessMetricDataSourceValue `tfsdk:"business_metrics"`
 }
 
-// type businessMetricsDataSourceModel datasource_business_metrics.BusinessMetricsModel
-
 func (d *businessMetricsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_business_metrics"
 }

--- a/vantage/resource_business_metric/business_metric_resource_gen.go
+++ b/vantage/resource_business_metric/business_metric_resource_gen.go
@@ -86,15 +86,11 @@ func BusinessMetricResourceSchema(ctx context.Context) schema.Schema {
 							Required: true,
 						},
 						"date": schema.StringAttribute{
-							Required:            true,
-							Description:         "The date of the Business Metric Value. ISO 8601 formatted.",
-							MarkdownDescription: "The date of the Business Metric Value. ISO 8601 formatted.",
+							Required: true,
 						},
 						"label": schema.StringAttribute{
-							Optional:            true,
-							Computed:            true,
-							Description:         "The label of the Business Metric Value.",
-							MarkdownDescription: "The label of the Business Metric Value.",
+							Optional: true,
+							Computed: true,
 						},
 					},
 					CustomType: ValuesType{


### PR DESCRIPTION
Changing how we handle creation of business metrics via Terraform. Now that `values` is not returned in the API response, when  a user specifies `values` in the Terraform code, we pass that directly to the state of the resource _after_ the API has returned, so that the state of `values` is avoids being "unknown" after the operation. In most other interactions with the API, the value is set when reading the payload; here, we set it manually.