### PR TITLE
Remove the planmodifier from start_date and end_date.

### DIFF
--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -229,13 +229,11 @@ func (r CostReportResource) Read(ctx context.Context, req resource.ReadRequest, 
 	state.Title = types.StringValue(out.Payload.Title)
 	state.Filter = types.StringValue(out.Payload.Filter)
 	state.Groupings = types.StringValue(out.Payload.Groupings)
+	state.StartDate = types.StringValue(out.Payload.StartDate)
+	state.EndDate = types.StringValue(out.Payload.EndDate)
 	state.PreviousPeriodStartDate = types.StringValue(out.Payload.PreviousPeriodStartDate)
 	state.PreviousPeriodEndDate = types.StringValue(out.Payload.PreviousPeriodEndDate)
 	state.DateInterval = types.StringValue(out.Payload.DateInterval)
-	// if out.Payload.DateInterval == "custom" {
-	state.StartDate = types.StringValue(out.Payload.StartDate)
-	state.EndDate = types.StringValue(out.Payload.EndDate)
-	// }
 	state.ChartType = types.StringValue(out.Payload.ChartType)
 	state.DateBin = types.StringValue(out.Payload.DateBin)
 	state.WorkspaceToken = types.StringValue(out.Payload.WorkspaceToken)

--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -75,17 +75,11 @@ func (r CostReportResource) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "Start date to apply to the Cost Report.",
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"end_date": schema.StringAttribute{
 				MarkdownDescription: "End date to apply to the Cost Report.",
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"previous_period_start_date": schema.StringAttribute{
 				MarkdownDescription: "Start date to apply to the Cost Report.",
@@ -235,11 +229,13 @@ func (r CostReportResource) Read(ctx context.Context, req resource.ReadRequest, 
 	state.Title = types.StringValue(out.Payload.Title)
 	state.Filter = types.StringValue(out.Payload.Filter)
 	state.Groupings = types.StringValue(out.Payload.Groupings)
-	state.StartDate = types.StringValue(out.Payload.StartDate)
-	state.EndDate = types.StringValue(out.Payload.EndDate)
 	state.PreviousPeriodStartDate = types.StringValue(out.Payload.PreviousPeriodStartDate)
 	state.PreviousPeriodEndDate = types.StringValue(out.Payload.PreviousPeriodEndDate)
 	state.DateInterval = types.StringValue(out.Payload.DateInterval)
+	// if out.Payload.DateInterval == "custom" {
+	state.StartDate = types.StringValue(out.Payload.StartDate)
+	state.EndDate = types.StringValue(out.Payload.EndDate)
+	// }
 	state.ChartType = types.StringValue(out.Payload.ChartType)
 	state.DateBin = types.StringValue(out.Payload.DateBin)
 	state.WorkspaceToken = types.StringValue(out.Payload.WorkspaceToken)

--- a/vantage/cost_report_resource_test.go
+++ b/vantage/cost_report_resource_test.go
@@ -1,0 +1,62 @@
+package vantage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/vantage-sh/terraform-provider-vantage/vantage/acctest"
+)
+
+func TestAccCostReport(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{ // create cost report
+				Config: costReportTF("test", "costs.provider = 'aws'"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_cost_report.test", "title", "test"),
+				),
+			},
+			{
+				Config: costReportWithoutDatesTF("test", "costs.provider = 'aws'"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_cost_report.test", "title", "test"),
+					resource.TestCheckResourceAttrSet("vantage_cost_report.test", "start_date"),
+					resource.TestCheckResourceAttrSet("vantage_cost_report.test", "end_date"),
+				),
+			},
+		},
+	})
+}
+
+func costReportTF(resourceTitle, filter string) string {
+	return fmt.Sprintf(`
+  data "vantage_workspaces" "test" {}
+
+	resource "vantage_cost_report" "test" {
+		workspace_token = data.vantage_workspaces.test.workspaces[0].token
+		title = "%s"
+		filter = "%s"
+		chart_type = "line"
+		date_bin = "day"
+		date_interval = "custom"
+		start_date = "2025-01-01"
+		end_date = "2025-01-31"
+}`, resourceTitle, filter)
+}
+
+func costReportWithoutDatesTF(resourceTitle, filter string) string {
+	return fmt.Sprintf(`
+  data "vantage_workspaces" "test" {}
+
+	resource "vantage_cost_report" "test" {
+		workspace_token = data.vantage_workspaces.test.workspaces[0].token
+		title = "%s"
+		filter = "%s"
+		chart_type = "line"
+		date_bin = "day"
+		date_interval = "last_month"
+}`, resourceTitle, filter)
+}


### PR DESCRIPTION
These values need to be allowed to be handled as computed properties that can change from month to month. The inclusion of the `stringplanmodifier.UseStateForUnknown(),` for these fields caused problems because it is meant to be used "when it is known that an unconfigured value will remain the same after a resource update." [link](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier#UseStateForUnknown)

This is in response to this error:

![Screenshot 2025-02-04 at 4 07 02 PM (1)](https://github.com/user-attachments/assets/588a2e39-6286-43d6-bc40-b00b8dcd2ed1)

I havent had a chance to see the terraform code this error was occurring in, but my hunch is that when we crossed the month barrier, the start_date and end_date values for a report changed when the date interval was set to last_x_months.
