### PR TITLE
fix: Allow unset of groupings by storing as empty string.

### DIFF
--- a/examples/cost_report/main.tf
+++ b/examples/cost_report/main.tf
@@ -6,9 +6,10 @@ terraform {
   }
 }
 
+data "vantage_workspaces" "demo" {}
 resource "vantage_folder" "demo_folder" {
   title           = "Demo Folder"
-  workspace_token = "wrkspc_47c3254c790e9351"
+  workspace_token = data.vantage_workspaces.demo.workspaces[0].token
 }
 
 resource "vantage_folder" "demo_folder_child" {
@@ -19,7 +20,7 @@ resource "vantage_folder" "demo_folder_child" {
 resource "vantage_saved_filter" "demo_filter" {
   title           = "Demo Saved Filter"
   filter          = "(costs.provider = 'aws')"
-  workspace_token = "wrkspc_47c3254c790e9351"
+  workspace_token = data.vantage_workspaces.demo.workspaces[0].token
 }
 
 resource "vantage_cost_report" "demo_report" {
@@ -27,6 +28,8 @@ resource "vantage_cost_report" "demo_report" {
   filter              = "costs.provider = 'kubernetes'"
   saved_filter_tokens = [vantage_saved_filter.demo_filter.token]
   title               = "Demo Report"
+  date_bin = "day"
+  chart_type = "line"
 }
 resource "vantage_dashboard" "demo_dashboard" {
   title         = "Demo Dashboard"
@@ -37,7 +40,7 @@ resource "vantage_dashboard" "demo_dashboard" {
       widgetable_token = vantage_cost_report.demo_report.token
     }
   ]
-  workspace_token = "wrkspc_47c3254c790e9351"
+  workspace_token = data.vantage_workspaces.demo.workspaces[0].token
   # saved_filter_tokens = [vantage_saved_filter.demo_filter.token]
 }
 
@@ -51,7 +54,7 @@ resource "vantage_team" "demo_team_2" {
   name             = "Another Demo Team"
   description      = "Demo Team Description"
   user_tokens      = ["usr_36b848747e1683bc", "usr_899b013c355547db"]
-  workspace_tokens = ["wrkspc_47c3254c790e9351"]
+  workspace_tokens = [ data.vantage_workspaces.demo.workspaces[0].token ]
 }
 resource "vantage_access_grant" "demo_access_grant" {
   team_token     = vantage_team.demo_team.token
@@ -89,8 +92,6 @@ data "vantage_business_metrics" "demo2" {}
 output "business_metrics" {
   value = data.vantage_business_metrics.demo2
 }
-
-
 
 resource "vantage_budget" "demo_budget" {
   name              = "Demo Budget"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/vantage-sh/vantage-go v0.0.52
+	github.com/vantage-sh/vantage-go v0.0.53
 )
 
 // replace github.com/vantage-sh/vantage-go => ../vantage-go

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/vantage-sh/vantage-go v0.0.52 h1:0M82JQAT4zwtVd37wzeE24/oouEWNPpyUXnpotPmqGM=
-github.com/vantage-sh/vantage-go v0.0.52/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
+github.com/vantage-sh/vantage-go v0.0.53 h1:BR2pYTGHNjkWLhamT+wy4JroaGVj/dDBw4DJOCVz9Bc=
+github.com/vantage-sh/vantage-go v0.0.53/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
@@ -70,6 +71,8 @@ func (r CostReportResource) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "Grouping aggregations applied to the filtered data.",
 				Optional:            true,
 				Computed:            true,
+				// https://discuss.hashicorp.com/t/framework-migration-test-produces-non-empty-plan/54523/8
+				Default: stringdefault.StaticString(""),
 			},
 			"start_date": schema.StringAttribute{
 				MarkdownDescription: "Start date to apply to the Cost Report.",

--- a/vantage/cost_report_resource_test.go
+++ b/vantage/cost_report_resource_test.go
@@ -31,6 +31,28 @@ func TestAccCostReport(t *testing.T) {
 	})
 }
 
+func TestAccCostReport_grouping(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{ // create cost report
+				Config: costReportWithGrouping(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_cost_report.test-grouping", "groupings", "service"),
+				),
+			},
+			{
+				Config: costReportWithoutGrouping(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_cost_report.test-grouping", "groupings", ""),
+				),
+			},
+		},
+	},
+	)
+}
+
 func costReportTF(resourceTitle, filter string) string {
 	return fmt.Sprintf(`
   data "vantage_workspaces" "test" {}
@@ -59,4 +81,31 @@ func costReportWithoutDatesTF(resourceTitle, filter string) string {
 		date_bin = "day"
 		date_interval = "last_month"
 }`, resourceTitle, filter)
+}
+
+func costReportWithGrouping() string {
+	return `
+  data "vantage_workspaces" "test" {}
+
+	resource "vantage_cost_report" "test-grouping" {
+		workspace_token = data.vantage_workspaces.test.workspaces[0].token
+		title = "test"
+		filter = "costs.provider = 'aws'"
+		chart_type = "line"
+		date_bin = "day"
+		groupings = "service"
+}`
+}
+
+func costReportWithoutGrouping() string {
+	return `
+  data "vantage_workspaces" "test" {}
+
+	resource "vantage_cost_report" "test-grouping" {
+		workspace_token = data.vantage_workspaces.test.workspaces[0].token
+		title = "test"
+		filter = "costs.provider = 'aws'"
+		chart_type = "line"
+		date_bin = "day"
+}`
 }


### PR DESCRIPTION
To unset the groupings attribute, we pass an empty string as the value in the API request. The API then responds with a payload that has a null value for the groupings. 

There is a known issue in the provider framework when attempting to set a previously-known-value to null : https://discuss.hashicorp.com/t/after-applying-this-test-step-and-performing-a-terraform-refresh-the-plan-was-not-empty/42835

The hack solution is to store the groupings value as an empty string in terraform state when it has been removed.