### PR TITLE
Fix parsing of start_date and end_date in kubernetes efficiency report resource

### DIFF
--- a/vantage/kubernetes_efficiency_report_resource_model.go
+++ b/vantage/kubernetes_efficiency_report_resource_model.go
@@ -3,7 +3,6 @@ package vantage
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -26,27 +25,27 @@ func (r *kubernetesEfficiencyReportModel) applyPayload(ctx context.Context, payl
 	r.DateInterval = types.StringValue(payload.DateInterval)
 	r.Default = types.BoolValue(payload.Default)
 
-	startDate, err := time.Parse(strfmt.RFC3339Millis, payload.StartDate)
+	// startDate, err := time.Parse("2006-01-02", payload.StartDate)
 
-	if err != nil {
-		d := diag.Diagnostics{}
-		d.AddError("error parsing start date", err.Error())
-		return d
-	}
+	// if err != nil {
+	// 	d := diag.Diagnostics{}
+	// 	d.AddError("error parsing start date", err.Error())
+	// 	return d
+	// }
 
-	tfDate := strfmt.Date(startDate)
-	r.StartDate = types.StringValue(tfDate.String())
+	// tfDate := strfmt.Date(startDate)
+	r.StartDate = types.StringValue(payload.StartDate)
 
-	endDate, err := time.Parse(strfmt.RFC3339Millis, payload.EndDate)
+	// endDate, err := time.Parse("2006-01-02", payload.EndDate)
 
-	if err != nil {
-		d := diag.Diagnostics{}
-		d.AddError("error parsing end date", err.Error())
-		return d
-	}
+	// if err != nil {
+	// 	d := diag.Diagnostics{}
+	// 	d.AddError("error parsing end date", err.Error())
+	// 	return d
+	// }
 
-	tfDate = strfmt.Date(endDate)
-	r.EndDate = types.StringValue(tfDate.String())
+	// tfDate = strfmt.Date(endDate)
+	r.EndDate = types.StringValue(payload.EndDate)
 
 	groupings := strings.Split(payload.Groupings, ",")
 

--- a/vantage/kubernetes_efficiency_report_resource_model.go
+++ b/vantage/kubernetes_efficiency_report_resource_model.go
@@ -24,27 +24,7 @@ func (r *kubernetesEfficiencyReportModel) applyPayload(ctx context.Context, payl
 	r.DateBucket = types.StringValue(payload.DateBucket)
 	r.DateInterval = types.StringValue(payload.DateInterval)
 	r.Default = types.BoolValue(payload.Default)
-
-	// startDate, err := time.Parse("2006-01-02", payload.StartDate)
-
-	// if err != nil {
-	// 	d := diag.Diagnostics{}
-	// 	d.AddError("error parsing start date", err.Error())
-	// 	return d
-	// }
-
-	// tfDate := strfmt.Date(startDate)
 	r.StartDate = types.StringValue(payload.StartDate)
-
-	// endDate, err := time.Parse("2006-01-02", payload.EndDate)
-
-	// if err != nil {
-	// 	d := diag.Diagnostics{}
-	// 	d.AddError("error parsing end date", err.Error())
-	// 	return d
-	// }
-
-	// tfDate = strfmt.Date(endDate)
 	r.EndDate = types.StringValue(payload.EndDate)
 
 	groupings := strings.Split(payload.Groupings, ",")

--- a/vantage/kubernetes_efficiency_report_resource_test.go
+++ b/vantage/kubernetes_efficiency_report_resource_test.go
@@ -32,6 +32,14 @@ func TestKubernetesReport(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_kubernetes_efficiency_report.kubernetes_efficiency_report", "filter", "kubernetes.cluster_id = 'bar'"),
 				),
 			},
+			{
+				// update resource report to use date interval
+				Config: testAccKubernetesReportDateInterval(rUpdatedTitle, "kubernetes.cluster_id = 'bar'"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_kubernetes_efficiency_report.kubernetes_efficiency_report", "title", rUpdatedTitle),
+					resource.TestCheckResourceAttr("vantage_kubernetes_efficiency_report.kubernetes_efficiency_report", "filter", "kubernetes.cluster_id = 'bar'"),
+				),
+			},
 		},
 	})
 }
@@ -50,6 +58,23 @@ resource "vantage_kubernetes_efficiency_report" "kubernetes_efficiency_report" {
 	date_interval = "custom"
 	start_date = "2024-01-01"
 	end_date = "2024-01-31"
+	groupings = ["namespace","label:app"]
+}
+`, title, filter)
+}
+
+func testAccKubernetesReportDateInterval(title, filter string) string {
+	return fmt.Sprintf(`
+
+data "vantage_workspaces" "test" {}
+
+resource "vantage_kubernetes_efficiency_report" "kubernetes_efficiency_report" {
+	workspace_token = data.vantage_workspaces.test.workspaces[0].token
+  title = %[1]q
+	filter = %[2]q
+	aggregated_by = "amount"
+	date_bucket = "week"
+	date_interval = "last_7_days"
 	groupings = ["namespace","label:app"]
 }
 `, title, filter)


### PR DESCRIPTION
Treat start_date and end_date as strings, rely on server for validation and returning the dates in the expected format of YYYY-MM-DD.

The companion to this is https://github.com/vantage-sh/core/pull/12000
