### PR TITLE
fix: Dashboard can be created with date_interval

### DIFF
--- a/vantage/dashboard_resource.go
+++ b/vantage/dashboard_resource.go
@@ -98,7 +98,7 @@ func (r DashboardResource) Schema(ctx context.Context, req resource.SchemaReques
 			stringplanmodifier.UseStateForUnknown(),
 			&NullableModifier{},
 		},
-		MarkdownDescription: attrs["end_date"].GetMarkdownDescription(),
+		MarkdownDescription: attrs["date_interval"].GetMarkdownDescription(),
 	}
 
 	s.Attributes["start_date"] = schema.StringAttribute{
@@ -142,7 +142,6 @@ func (r DashboardResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	data.DateInterval = types.StringUnknown()
 	body := data.toCreate(ctx, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/vantage/dashboard_resource_model.go
+++ b/vantage/dashboard_resource_model.go
@@ -2,10 +2,12 @@ package vantage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/vantage-sh/terraform-provider-vantage/vantage/resource_dashboard"
 	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
 )
@@ -15,6 +17,7 @@ type dashboardModel resource_dashboard.DashboardModel
 func (m *dashboardModel) applyPayload(ctx context.Context, payload *modelsv2.Dashboard) diag.Diagnostics {
 	m.CreatedAt = types.StringValue(payload.CreatedAt)
 	m.DateBin = types.StringValue(payload.DateBin)
+	tflog.Debug(ctx, fmt.Sprintf("DateInterval is not null %s", payload.DateInterval))
 	if payload.DateInterval != "" {
 		m.DateInterval = types.StringValue(payload.DateInterval)
 	} else {
@@ -119,7 +122,7 @@ func (m *dashboardModel) toCreate(ctx context.Context, diags *diag.Diagnostics) 
 			widgets = append(widgets, widget)
 		}
 	}
-
+	tflog.Debug(ctx, fmt.Sprintf("DateInterval create %s", m.DateInterval.ValueString()))
 	payload := &modelsv2.CreateDashboard{
 		DateBin:           m.DateBin.ValueString(),
 		SavedFilterTokens: fromStringsValue(savedFilterTokens),

--- a/vantage/dashboard_resource_test.go
+++ b/vantage/dashboard_resource_test.go
@@ -127,6 +127,34 @@ func TestAccDashboard_basic(t *testing.T) {
 	})
 }
 
+func TestAccDashboard_hasDateInterval(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDashboard_withDateInterval(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_dashboard.test-date-interval", "date_interval", "this_month"),
+				),
+			},
+			{
+				Config: testAccDashboard_nullDateInterval(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("vantage_dashboard.test-date-interval", "date_interval"),
+					resource.TestCheckResourceAttr("vantage_dashboard.test-date-interval", "start_date", ""),
+				),
+			},
+			{
+				Config: testAccDashboard_withDates(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("vantage_dashboard.test-date-interval", "date_interval"),
+					resource.TestCheckResourceAttr("vantage_dashboard.test-date-interval", "start_date", "2023-01-01"),
+				),
+			},
+		}})
+}
+
 func TestAccDashboard_dateInterval(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },


### PR DESCRIPTION
Fixes a bug introduced in previous PR where I was setting the config's DateInterval to "unknown" before creating the dashboard, which left the date_interval parameter out of the http request.

Now, the date_interval parameter is passed in the POST, and the responding API response matches what was set in the terraform code. So, if your terraform had "last_6_months", the API response will say "last_6_months", instead of null.