### PR TITLE
chore: Run + Require successful test runs for PRs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,28 +1,32 @@
 name: Test
 
 on:
+  pull_request:
   push:
     branches:
       - main
-      - '*'
+      - "*"
+
+concurrency:
+  group: tests-acceptance
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.21
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
 
-    - name: Run Tests
-      run: go test ./...
+      - name: Run Tests
+        run: go test ./...
 
-    - name: Run Acceptance Tests
-      env:
-        VANTAGE_API_TOKEN: ${{ secrets.VANTAGE_API_TOKEN }}
-      run: TF_ACC=1 go test -v ./vantage
+      - name: Run Acceptance Tests
+        env:
+          VANTAGE_API_TOKEN: ${{ secrets.VANTAGE_API_TOKEN }}
+        run: TF_ACC=1 go test -v ./vantage


### PR DESCRIPTION
- External contributions must be triggered manually
- No concurrency; only one `tests-acceptance` job permitted at a time

completes ENG-219