### PR TITLE
feat: Add support for sql query billing rule params.

### DIFF
--- a/vantage/billing_rule_resource.go
+++ b/vantage/billing_rule_resource.go
@@ -123,6 +123,15 @@ func (r *billingRuleResource) ValidateConfig(ctx context.Context, req resource.V
 		}
 	}
 
+	if data.Type.ValueString() == "custom" {
+		if data.SqlQuery.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("sql_query"),
+				"Missing Attribute Configuration",
+				"Expected sql_query to be present with custom type",
+			)
+		}
+	}
 }
 
 func (r *billingRuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -191,6 +200,11 @@ func (r *billingRuleResource) Schema(ctx context.Context, req resource.SchemaReq
 				Description:         "The subcategory of the Billing Rule.",
 				MarkdownDescription: "The subcategory of the Billing Rule.",
 			},
+			"sql_query": schema.StringAttribute{
+				Optional:            true,
+				Description:         "The SQL query of the Billing Rule.",
+				MarkdownDescription: "The SQL query of the Billing Rule.",
+			},
 			"title": schema.StringAttribute{
 				Required:            true,
 				Description:         "The title of the Billing Rule.",
@@ -214,6 +228,7 @@ func (r *billingRuleResource) Schema(ctx context.Context, req resource.SchemaReq
 						"adjustment",
 						"credit",
 						"charge",
+						"custom",
 					),
 				},
 			},

--- a/vantage/billing_rule_resource_model.go
+++ b/vantage/billing_rule_resource_model.go
@@ -23,6 +23,7 @@ type datasourceBillingRuleModel struct {
 	Service        types.String `tfsdk:"service"`
 	StartPeriod    types.String `tfsdk:"start_period"`
 	SubCategory    types.String `tfsdk:"sub_category"`
+	SqlQuery       types.String `tfsdk:"sql_query"`
 	Title          types.String `tfsdk:"title"`
 	Token          types.String `tfsdk:"token"`
 	Type           types.String `tfsdk:"type"`
@@ -47,6 +48,7 @@ func (m *billingRuleModel) toDatasourceModel() datasourceBillingRuleModel {
 		Service:        m.Service,
 		StartPeriod:    m.StartPeriod,
 		SubCategory:    m.SubCategory,
+		SqlQuery:       m.SqlQuery,
 		Title:          m.Title,
 		Token:          m.Token,
 		Type:           m.Type,
@@ -112,6 +114,10 @@ func (m *billingRuleModel) applyPayload(ctx context.Context, payload *modelsv2.B
 	if payload.SubCategory != "" {
 		m.SubCategory = types.StringValue(payload.SubCategory)
 	}
+
+		if payload.SQLQuery != "" {
+			m.SqlQuery = types.StringValue(payload.SQLQuery)
+		}
 	m.Title = types.StringValue(payload.Title)
 	m.Token = types.StringValue(payload.Token)
 	m.Type = types.StringValue(payload.Type)
@@ -131,6 +137,7 @@ func (m *billingRuleModel) toCreateModel(_ context.Context, _ *diag.Diagnostics)
 		Service:     m.Service.ValueStringPointer(),
 		StartPeriod: m.StartPeriod.ValueStringPointer(),
 		SubCategory: m.SubCategory.ValueStringPointer(),
+		SQLQuery:    m.SqlQuery.ValueStringPointer(),
 		Title:       m.Title.ValueStringPointer(),
 		Type:        m.Type.ValueStringPointer(),
 	}
@@ -149,6 +156,7 @@ func (m *billingRuleModel) toUpdateModel(_ context.Context, _ *diag.Diagnostics)
 		Service:     m.Service.ValueString(),
 		StartPeriod: m.StartPeriod.ValueString(),
 		SubCategory: m.SubCategory.ValueString(),
+		SQLQuery:    m.SqlQuery.ValueString(),
 		Title:       m.Title.ValueString(),
 	}
 }

--- a/vantage/billing_rule_resource_test.go
+++ b/vantage/billing_rule_resource_test.go
@@ -92,6 +92,24 @@ func TestAccBillingRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_apply_to_all", "apply_to_all", "false"),
 				),
 			},
+			{
+				// create custom rule
+				Config: testAccBillingRule_custom("UPDATE aws SET aws.product/ProductFamily = 'Support'\nWHERE aws.lineItem/LineItemType = 'Fee' AND aws.product/ProductName = 'AWS Support'"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_custom", "title", "test_custom"),
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_custom", "type", "custom"),
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_custom", "sql_query", "UPDATE aws SET aws.product/ProductFamily = 'Support'\nWHERE aws.lineItem/LineItemType = 'Fee' AND aws.product/ProductName = 'AWS Support'"),
+				),
+			},
+			{
+				// update custom rule
+				Config: testAccBillingRule_custom("UPDATE aws SET aws.product/ProductFamily = 'Support'\nWHERE aws.lineItem/LineItemType = 'Fee'"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_custom", "title", "test_custom"),
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_custom", "type", "custom"),
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_custom", "sql_query", "UPDATE aws SET aws.product/ProductFamily = 'Support'\nWHERE aws.lineItem/LineItemType = 'Fee'"),
+				),
+			},
 		},
 	})
 }
@@ -140,4 +158,14 @@ func testAccBillingRule_charge(title, service, category, subCategory, startPerio
 		amount = %[6]f
 	}
 	`, title, service, category, subCategory, startPeriod, amount)
+}
+
+func testAccBillingRule_custom(query string) string {
+	return fmt.Sprintf(`
+resource "vantage_billing_rule" "test_custom" {
+	title = "test_custom"
+	type = "custom"
+	sql_query = %[1]q
+}
+	`, query)
 }

--- a/vantage/datasource_billing_rules/billing_rules_data_source_gen.go
+++ b/vantage/datasource_billing_rules/billing_rules_data_source_gen.go
@@ -66,6 +66,11 @@ func BillingRulesDataSourceSchema(ctx context.Context) schema.Schema {
 							Description:         "The service for the BillingRule (Charge).",
 							MarkdownDescription: "The service for the BillingRule (Charge).",
 						},
+						"sql_query": schema.StringAttribute{
+							Computed:            true,
+							Description:         "The SQL query for the BillingRule (Custom).",
+							MarkdownDescription: "The SQL query for the BillingRule (Custom).",
+						},
 						"start_date": schema.StringAttribute{
 							Computed:            true,
 							Description:         "The start date of the BillingRule.",
@@ -298,6 +303,24 @@ func (t BillingRulesType) ValueFromObject(ctx context.Context, in basetypes.Obje
 			fmt.Sprintf(`service expected to be basetypes.StringValue, was: %T`, serviceAttribute))
 	}
 
+	sqlQueryAttribute, ok := attributes["sql_query"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`sql_query is missing from object`)
+
+		return nil, diags
+	}
+
+	sqlQueryVal, ok := sqlQueryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`sql_query expected to be basetypes.StringValue, was: %T`, sqlQueryAttribute))
+	}
+
 	startDateAttribute, ok := attributes["start_date"]
 
 	if !ok {
@@ -420,6 +443,7 @@ func (t BillingRulesType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		EndDate:          endDateVal,
 		Percentage:       percentageVal,
 		Service:          serviceVal,
+		SqlQuery:         sqlQueryVal,
 		StartDate:        startDateVal,
 		StartPeriod:      startPeriodVal,
 		SubCategory:      subCategoryVal,
@@ -655,6 +679,24 @@ func NewBillingRulesValue(attributeTypes map[string]attr.Type, attributes map[st
 			fmt.Sprintf(`service expected to be basetypes.StringValue, was: %T`, serviceAttribute))
 	}
 
+	sqlQueryAttribute, ok := attributes["sql_query"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`sql_query is missing from object`)
+
+		return NewBillingRulesValueUnknown(), diags
+	}
+
+	sqlQueryVal, ok := sqlQueryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`sql_query expected to be basetypes.StringValue, was: %T`, sqlQueryAttribute))
+	}
+
 	startDateAttribute, ok := attributes["start_date"]
 
 	if !ok {
@@ -777,6 +819,7 @@ func NewBillingRulesValue(attributeTypes map[string]attr.Type, attributes map[st
 		EndDate:          endDateVal,
 		Percentage:       percentageVal,
 		Service:          serviceVal,
+		SqlQuery:         sqlQueryVal,
 		StartDate:        startDateVal,
 		StartPeriod:      startPeriodVal,
 		SubCategory:      subCategoryVal,
@@ -864,6 +907,7 @@ type BillingRulesValue struct {
 	EndDate          basetypes.StringValue `tfsdk:"end_date"`
 	Percentage       basetypes.StringValue `tfsdk:"percentage"`
 	Service          basetypes.StringValue `tfsdk:"service"`
+	SqlQuery         basetypes.StringValue `tfsdk:"sql_query"`
 	StartDate        basetypes.StringValue `tfsdk:"start_date"`
 	StartPeriod      basetypes.StringValue `tfsdk:"start_period"`
 	SubCategory      basetypes.StringValue `tfsdk:"sub_category"`
@@ -874,7 +918,7 @@ type BillingRulesValue struct {
 }
 
 func (v BillingRulesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 15)
+	attrTypes := make(map[string]tftypes.Type, 16)
 
 	var val tftypes.Value
 	var err error
@@ -888,6 +932,7 @@ func (v BillingRulesValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 	attrTypes["end_date"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["percentage"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["service"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["sql_query"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["start_date"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["start_period"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["sub_category"] = basetypes.StringType{}.TerraformType(ctx)
@@ -899,7 +944,7 @@ func (v BillingRulesValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 15)
+		vals := make(map[string]tftypes.Value, 16)
 
 		val, err = v.Amount.ToTerraformValue(ctx)
 
@@ -972,6 +1017,14 @@ func (v BillingRulesValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		}
 
 		vals["service"] = val
+
+		val, err = v.SqlQuery.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["sql_query"] = val
 
 		val, err = v.StartDate.ToTerraformValue(ctx)
 
@@ -1050,24 +1103,35 @@ func (v BillingRulesValue) String() string {
 func (v BillingRulesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"amount":           basetypes.StringType{},
+		"apply_to_all":     basetypes.BoolType{},
+		"category":         basetypes.StringType{},
+		"charge_type":      basetypes.StringType{},
+		"created_at":       basetypes.StringType{},
+		"created_by_token": basetypes.StringType{},
+		"end_date":         basetypes.StringType{},
+		"percentage":       basetypes.StringType{},
+		"service":          basetypes.StringType{},
+		"sql_query":        basetypes.StringType{},
+		"start_date":       basetypes.StringType{},
+		"start_period":     basetypes.StringType{},
+		"sub_category":     basetypes.StringType{},
+		"title":            basetypes.StringType{},
+		"token":            basetypes.StringType{},
+		"type":             basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"amount":           basetypes.StringType{},
-			"apply_to_all":     basetypes.BoolType{},
-			"category":         basetypes.StringType{},
-			"charge_type":      basetypes.StringType{},
-			"created_at":       basetypes.StringType{},
-			"created_by_token": basetypes.StringType{},
-			"end_date":         basetypes.StringType{},
-			"percentage":       basetypes.StringType{},
-			"service":          basetypes.StringType{},
-			"start_date":       basetypes.StringType{},
-			"start_period":     basetypes.StringType{},
-			"sub_category":     basetypes.StringType{},
-			"title":            basetypes.StringType{},
-			"token":            basetypes.StringType{},
-			"type":             basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"amount":           v.Amount,
 			"apply_to_all":     v.ApplyToAll,
@@ -1078,6 +1142,7 @@ func (v BillingRulesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectV
 			"end_date":         v.EndDate,
 			"percentage":       v.Percentage,
 			"service":          v.Service,
+			"sql_query":        v.SqlQuery,
 			"start_date":       v.StartDate,
 			"start_period":     v.StartPeriod,
 			"sub_category":     v.SubCategory,
@@ -1140,6 +1205,10 @@ func (v BillingRulesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.SqlQuery.Equal(other.SqlQuery) {
+		return false
+	}
+
 	if !v.StartDate.Equal(other.StartDate) {
 		return false
 	}
@@ -1186,6 +1255,7 @@ func (v BillingRulesValue) AttributeTypes(ctx context.Context) map[string]attr.T
 		"end_date":         basetypes.StringType{},
 		"percentage":       basetypes.StringType{},
 		"service":          basetypes.StringType{},
+		"sql_query":        basetypes.StringType{},
 		"start_date":       basetypes.StringType{},
 		"start_period":     basetypes.StringType{},
 		"sub_category":     basetypes.StringType{},

--- a/vantage/resource_billing_rule/billing_rule_resource_gen.go
+++ b/vantage/resource_billing_rule/billing_rule_resource_gen.go
@@ -61,6 +61,11 @@ func BillingRuleResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The service of the BillingRule.",
 				MarkdownDescription: "The service of the BillingRule.",
 			},
+			"sql_query": schema.StringAttribute{
+				Required:            true,
+				Description:         "UPDATE costs SET costs.amount = costs.amount * 0.95",
+				MarkdownDescription: "UPDATE costs SET costs.amount = costs.amount * 0.95",
+			},
 			"start_date": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -97,6 +102,7 @@ func BillingRuleResourceSchema(ctx context.Context) schema.Schema {
 						"adjustment",
 						"credit",
 						"charge",
+						"custom",
 					),
 				},
 			},
@@ -114,6 +120,7 @@ type BillingRuleModel struct {
 	EndDate        types.String  `tfsdk:"end_date"`
 	Percentage     types.Float64 `tfsdk:"percentage"`
 	Service        types.String  `tfsdk:"service"`
+	SqlQuery       types.String  `tfsdk:"sql_query"`
 	StartDate      types.String  `tfsdk:"start_date"`
 	StartPeriod    types.String  `tfsdk:"start_period"`
 	SubCategory    types.String  `tfsdk:"sub_category"`


### PR DESCRIPTION
See also https://github.com/vantage-sh/vantage-go/pull/35.

Some of the input/output testing is a little particular (e.g. `\n` before WHEREs) to get around current formatting in the API, might want to revisit with a different simpler query later, but seems fine for now.