### PR TITLE
fix: Relax optional fields.

### DIFF
--- a/vantage/billing_rule_resource_model.go
+++ b/vantage/billing_rule_resource_model.go
@@ -68,6 +68,8 @@ func (m *billingRuleModel) applyPayload(ctx context.Context, payload *modelsv2.B
 		}
 
 		m.Percentage = types.Float64Value(rate)
+	} else {
+		m.Percentage = types.Float64Value(0.0)
 	}
 
 	if payload.Amount != "" {
@@ -78,6 +80,8 @@ func (m *billingRuleModel) applyPayload(ctx context.Context, payload *modelsv2.B
 			return d
 		}
 		m.Amount = types.Float64Value(amount)
+	} else {
+		m.Amount = types.Float64Value(0.0)
 	}
 
 	m.ApplyToAll = types.BoolValue(payload.ApplyToAll)
@@ -93,11 +97,17 @@ func (m *billingRuleModel) applyPayload(ctx context.Context, payload *modelsv2.B
 	} else {
 		m.StartDate = types.StringNull()
 	}
+
 	if payload.Category != "" {
 		m.Category = types.StringValue(payload.Category)
+	} else {
+		m.Category = types.StringNull()
 	}
+
 	if payload.ChargeType != "" {
 		m.ChargeType = types.StringValue(payload.ChargeType)
+	} else {
+		m.ChargeType = types.StringNull()
 	}
 
 	m.CreatedAt = types.StringValue(payload.CreatedAt)
@@ -105,19 +115,28 @@ func (m *billingRuleModel) applyPayload(ctx context.Context, payload *modelsv2.B
 
 	if payload.Service != "" {
 		m.Service = types.StringValue(payload.Service)
+	} else {
+		m.Service = types.StringNull()
 	}
 
 	if payload.StartPeriod != "" {
 		m.StartPeriod = types.StringValue(payload.StartPeriod)
+	} else {
+		m.StartPeriod = types.StringNull()
 	}
 
 	if payload.SubCategory != "" {
 		m.SubCategory = types.StringValue(payload.SubCategory)
+	} else {
+		m.SubCategory = types.StringNull()
 	}
 
 	if payload.SQLQuery != "" {
 		m.SqlQuery = types.StringValue(payload.SQLQuery)
+	} else {
+		m.SqlQuery = types.StringNull()
 	}
+
 	m.Title = types.StringValue(payload.Title)
 	m.Token = types.StringValue(payload.Token)
 	m.Type = types.StringValue(payload.Type)

--- a/vantage/billing_rule_resource_test.go
+++ b/vantage/billing_rule_resource_test.go
@@ -54,8 +54,6 @@ func TestAccBillingRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_adjustment_required_only", "title", "test_adjustment_required_only_title"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_adjustment_required_only", "type", "adjustment"),
-					resource.TestCheckResourceAttr("vantage_billing_rule.test_adjustment_required_only", "service", ""),
-					resource.TestCheckResourceAttr("vantage_billing_rule.test_adjustment_required_only", "category", ""),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_adjustment_required_only", "percentage", "50"),
 					resource.TestCheckResourceAttrSet("vantage_billing_rule.test_adjustment_required_only", "token"),
 				),
@@ -67,7 +65,7 @@ func TestAccBillingRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "service", "service"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "category", "category"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "sub_category", "subCategory"),
-					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "start_period", "2023-01-01"),
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "start_date", "2023-01-01"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "amount", "0.7"),
 					resource.TestCheckResourceAttrSet("vantage_billing_rule.test_charge", "token"),
 				),
@@ -79,7 +77,7 @@ func TestAccBillingRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "service", "service2"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "category", "category2"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "sub_category", "subCategory2"),
-					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "start_period", "2023-01-02"),
+					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "start_date", "2023-01-02"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_charge", "amount", "0.8"),
 				),
 			},
@@ -91,7 +89,6 @@ func TestAccBillingRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_credit", "category", "category"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_credit", "sub_category", "subCategory"),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_credit", "start_date", "2023-01-01"),
-					resource.TestCheckResourceAttr("vantage_billing_rule.test_credit", "start_period", ""),
 					resource.TestCheckResourceAttr("vantage_billing_rule.test_credit", "amount", "0.7"),
 					resource.TestCheckResourceAttrSet("vantage_billing_rule.test_credit", "token"),
 				),
@@ -144,13 +141,6 @@ resource "vantage_billing_rule" "test_exclusion" {
   title = %[1]q
 	type = "exclusion"
 	charge_type = %[2]q
-	start_period = ""
-	amount = 0.0
-	percentage = 0.0
-	service = ""
-	category = ""
-	sub_category = ""
-	sql_query = ""
 }
 `, title, chargeType)
 }
@@ -162,13 +152,6 @@ resource "vantage_billing_rule" "test_apply_to_all" {
 	type = "exclusion"
 	charge_type = "RIFee"
 	apply_to_all = %[1]t
-	start_period = ""
-	amount = 0.0
-	percentage = 0.0
-	service = ""
-	category = ""
-	sub_category = ""
-	sql_query = ""
 }
 	`, applyToAll)
 }
@@ -181,11 +164,6 @@ resource "vantage_billing_rule" "test_adjustment" {
 	service = %[2]q
 	category = %[3]q
 	percentage = %[4]f
-	start_period = ""
-	amount = 0.0
-	charge_type = ""
-	sub_category = ""
-	sql_query = ""
 }
 	`, title, service, category, percentage)
 }
@@ -195,19 +173,12 @@ func testAccBillingRule_adjustmentRequiredOnly(title string, percentage float32)
 resource "vantage_billing_rule" "test_adjustment_required_only" {
 	title = %[1]q
 	type = "adjustment"
-	service = ""
-	category = ""
 	percentage = %[2]f
-	start_period = ""
-	amount = 0.0
-	charge_type = ""
-	sub_category = ""
-	sql_query = ""
 }
 	`, title, percentage)
 }
 
-func testAccBillingRule_charge(title, service, category, subCategory, startPeriod string, amount float32) string {
+func testAccBillingRule_charge(title, service, category, subCategory, startDate string, amount float32) string {
 	return fmt.Sprintf(`
 	resource "vantage_billing_rule" "test_charge" {
 		title = %[1]q
@@ -215,13 +186,10 @@ func testAccBillingRule_charge(title, service, category, subCategory, startPerio
 		service = %[2]q
 		category = %[3]q
 		sub_category = %[4]q
-		start_period = %[5]q
+		start_date = %[5]q
 		amount = %[6]f
-		charge_type = ""
-		percentage = 0.0
-		sql_query = ""
 	}
-	`, title, service, category, subCategory, startPeriod, amount)
+	`, title, service, category, subCategory, startDate, amount)
 }
 
 func testAccBillingRule_credit(title, service, category, subCategory, startDate string, amount float32) string {
@@ -233,11 +201,7 @@ func testAccBillingRule_credit(title, service, category, subCategory, startDate 
 		category = %[3]q
 		sub_category = %[4]q
 		start_date = %[5]q
-		start_period = ""
 		amount = %[6]f
-		charge_type = ""
-		percentage = 0.0
-		sql_query = ""
 	}
 	`, title, service, category, subCategory, startDate, amount)
 }
@@ -248,13 +212,6 @@ resource "vantage_billing_rule" "test_custom" {
 	title = "test_custom"
 	type = "custom"
 	sql_query = %[1]q
-	charge_type = ""
-	start_period = ""
-	amount = 0.0
-	percentage = 0.0
-	service = ""
-	category = ""
-	sub_category = ""
 }
 	`, query)
 }


### PR DESCRIPTION
Adds default values for omitted billing rule fields (which are all optional in the sense that only some rule types have or require some fields), and relaxes the field checks in billing_rule_resource_test.

This is directionally more correct while being somewhat unsatisfying. Previously, we were defining these fields in the resource model [as pointers](https://github.com/vantage-sh/terraform-provider-vantage/pull/126/commits/17c2db05d0afb4aee6df285a2627c234676342c2), which allowed them to be nullable, but was running afoul of tests.

This returns us to a similar world wherein these values get defaults and don't need to explicitly set.