### PR TITLE
fix: Do not include chart_type or date_bin in the create/update requests if not specified.

### DIFF
--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -181,9 +181,16 @@ func (r CostReportResource) Create(ctx context.Context, req resource.CreateReque
 		DateInterval:            data.DateInterval.ValueString(),
 		PreviousPeriodStartDate: data.PreviousPeriodStartDate.ValueString(),
 		PreviousPeriodEndDate:   data.PreviousPeriodEndDate.ValueStringPointer(),
-		ChartType:               data.ChartType.ValueStringPointer(),
-		DateBin:                 data.DateBin.ValueStringPointer(),
 	}
+
+	if !data.ChartType.IsUnknown() && !data.ChartType.IsNull() {
+		body.ChartType = data.ChartType.ValueStringPointer()
+	}
+
+	if !data.DateBin.IsUnknown() && !data.DateBin.IsNull() {
+		body.DateBin = data.DateBin.ValueStringPointer()
+	}
+
 	params.WithCreateCostReport(body)
 	out, err := r.client.V2.Costs.CreateCostReport(params, r.client.Auth)
 	if err != nil {
@@ -294,8 +301,14 @@ func (r CostReportResource) Update(ctx context.Context, req resource.UpdateReque
 		Groupings:               data.Groupings.ValueString(),
 		PreviousPeriodStartDate: data.PreviousPeriodStartDate.ValueString(),
 		PreviousPeriodEndDate:   data.PreviousPeriodEndDate.ValueString(),
-		ChartType:               data.ChartType.ValueStringPointer(),
-		DateBin:                 data.DateBin.ValueStringPointer(),
+	}
+
+	if !data.ChartType.IsUnknown() && !data.ChartType.IsNull() {
+		model.ChartType = data.ChartType.ValueStringPointer()
+	}
+
+	if !data.DateBin.IsUnknown() && !data.DateBin.IsNull() {
+		model.DateBin = data.DateBin.ValueStringPointer()
 	}
 
 	if data.DateInterval.ValueString() == "custom" {

--- a/vantage/report_notification_resource_test.go
+++ b/vantage/report_notification_resource_test.go
@@ -25,7 +25,7 @@ func TestAccVantageReportNotification_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVantageReportNotification_CreateTeamTf("team-1") +
-					costReportTF(costReportTitle, costReportFilter) +
+					costReportTF("test", costReportTitle, costReportFilter) +
 					testAccVantageReportNotification_basicTf(id1, title1, change1, frequency1, costReportTitle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vantage_team.team", "name", "team-1"),


### PR DESCRIPTION
If you omit the date_bin and chart_type attributes from the vantage_cost_report, calling ValueStringPointer() on those attributes will return "" if the value is unknown. This "" value is not accepted by the API for these attributes, causing 400.

Now, we check if the value is not null and not unknown before setting its value in the request body. That way, the request body will correctly send a null value for chart_type or date_bin if you dont include it.