### PR TITLE
test: Acceptance test that verifies user email order is preserved.

### DIFF
--- a/vantage/team_resource_test.go
+++ b/vantage/team_resource_test.go
@@ -167,6 +167,40 @@ resource "vantage_team" "team" {
 
 
 
+func TestTeamUserEmailsOrder(t *testing.T) {
+	rName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Create a team with user_emails in reverse data-source order.
+				// If the API doesn't preserve input order, Terraform will error
+				// with "Provider produced inconsistent result after apply".
+				Config: testAccTeamWithUserEmailsReversed(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_team.team", "name", rName),
+					resource.TestCheckResourceAttr("vantage_team.team", "user_emails.#", "2"),
+					resource.TestCheckResourceAttrPair("vantage_team.team", "user_emails.0", "data.vantage_users.test", "users.1.email"),
+					resource.TestCheckResourceAttrPair("vantage_team.team", "user_emails.1", "data.vantage_users.test", "users.0.email"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTeamWithUserEmailsReversed(title string) string {
+	return fmt.Sprintf(`
+data "vantage_users" "test" {}
+resource "vantage_team" "team" {
+	name = %[1]q
+	description = ""
+	user_emails = [data.vantage_users.test.users[1].email, data.vantage_users.test.users[0].email]
+}
+`, title)
+}
+
 func testAccTeamWithUserTokens(title, description string) string {
 	return fmt.Sprintf(`
 data "vantage_workspaces" "test" {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds coverage for list ordering behavior without modifying provider or API logic.
> 
> **Overview**
> Adds a new acceptance test (`TestTeamUserEmailsOrder`) that creates a `vantage_team` with `user_emails` deliberately reversed from the `vantage_users` data source order, and asserts Terraform state preserves that exact ordering to catch inconsistent results after apply.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8777c614f92869cf3822071ad65563bc6ee19e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->