### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/vantage-sh/terraform-provider-vantage
 
-go 1.23
+go 1.26
 
-toolchain go1.23.0
+toolchain go1.26.2
 
 require (
 	github.com/go-openapi/runtime v0.26.0


### PR DESCRIPTION
## Summary
- Updates `go.mod` from Go 1.23 / toolchain go1.23.0 to Go 1.26 / toolchain go1.26.2
- Go 1.26.2 (released 2026-04-07) includes security fixes to the go command, compiler, and `archive/tar`, `crypto/tls`, `crypto/x509`, `html/template`, and `os` packages
- No dependency changes required — `go mod tidy` produced no diff beyond the version bump
- CI workflows already read the Go version from `go.mod` via `go-version-file`, so no workflow changes needed

## Test plan
- [ ] Unit tests pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the Go language/toolchain version in `go.mod` with no dependency or runtime logic changes. Main risk is CI/build breakage if any environments or tooling don’t yet support Go 1.26.
> 
> **Overview**
> Updates the module’s Go version in `go.mod` from `go 1.23` / `toolchain go1.23.0` to `go 1.26` / `toolchain go1.26.2`, with no other code or dependency changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f435111b756219b867d745e75562e5f40d2728e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->