### PR TITLE
feat(virtual_tag_config): expose label_transforms on values

### DIFF
--- a/docs/resources/virtual_tag_config.md
+++ b/docs/resources/virtual_tag_config.md
@@ -69,6 +69,7 @@ Required:
 
 Optional:
 
+- `filter` (String) The VQL filter this collapsed tag key applies to.
 - `providers` (List of String) The providers this collapsed tag key applies to. Defaults to all providers.
 
 
@@ -84,6 +85,7 @@ Optional:
 - `business_metric_token` (String) The token of an associated business metric.
 - `cost_metric` (Attributes) (see [below for nested schema](#nestedatt--values--cost_metric))
 - `date_ranges` (Attributes List) Date ranges restricting when this value applies. Each range has optional start_date and end_date (inclusive, YYYY-MM-DD). (see [below for nested schema](#nestedatt--values--date_ranges))
+- `label_transforms` (Attributes List) Label transforms applied to business metric labels. (see [below for nested schema](#nestedatt--values--label_transforms))
 - `name` (String) The name of the value.
 - `percentages` (Attributes List) Labeled percentage allocations for matching costs. (see [below for nested schema](#nestedatt--values--percentages))
 
@@ -111,6 +113,20 @@ Optional:
 
 - `end_date` (String) Inclusive end date (YYYY-MM-DD), or null for unbounded.
 - `start_date` (String) Inclusive start date (YYYY-MM-DD), or null for unbounded.
+
+
+<a id="nestedatt--values--label_transforms"></a>
+### Nested Schema for `values.label_transforms`
+
+Required:
+
+- `type` (String) The label transform type. One of `split` or `format`.
+
+Optional:
+
+- `delimiter` (String) Delimiter used by split transforms.
+- `index` (Number) Zero-based index used by split transforms.
+- `template` (String) Template used by format transforms.
 
 
 <a id="nestedatt--values--percentages"></a>

--- a/examples/resources/vantage_virtual_tag_config/resource.tf
+++ b/examples/resources/vantage_virtual_tag_config/resource.tf
@@ -21,5 +21,15 @@ resource "vantage_virtual_tag_config" "demo_virtual_tag_config" {
     #   filter = "(costs.provider = 'aws' AND costs.service = 'AmazonECS')"
     #   business_metric_token = ""
     # }
+    # Example: apply label_transforms to a business-metric-backed value to
+    # split a "&&&"-delimited project label and reformat it into a team tag.
+    # {
+    #   filter                = "costs.provider = 'aws'"
+    #   business_metric_token = "bsnss_mtrc_XXXXXXXX"
+    #   label_transforms = [
+    #     { type = "split", delimiter = "&&&", index = 0 },
+    #     { type = "format", template = "team-{0}" },
+    #   ]
+    # }
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/vantage-sh/vantage-go v0.1.0
+	github.com/vantage-sh/vantage-go v0.1.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/vantage-sh/vantage-go v0.1.1
+	github.com/vantage-sh/vantage-go v0.1.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/vantage-sh/vantage-go v0.1.1 h1:zegntoOQac96jP83zvD7gduYGLWE3A3kgAPyxH5Ncng=
 github.com/vantage-sh/vantage-go v0.1.1/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
+github.com/vantage-sh/vantage-go v0.1.2 h1:zkAAiaRitZnyTx4I+L8PaWh60Jr+JbgHTIVQUHl9KzE=
+github.com/vantage-sh/vantage-go v0.1.2/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/vantage-sh/vantage-go v0.1.0 h1:bWRD5/JVk6csqqTDnbSYqTMk9GvgGcaxgXF05bN2uyo=
-github.com/vantage-sh/vantage-go v0.1.0/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
+github.com/vantage-sh/vantage-go v0.1.1 h1:zegntoOQac96jP83zvD7gduYGLWE3A3kgAPyxH5Ncng=
+github.com/vantage-sh/vantage-go v0.1.1/go.mod h1:MsSI4gX/Wvkzo9kqWphZfE6puolmnbHcXSaoGkDCmXg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/vantage/datasource_virtual_tag_configs/virtual_tag_configs_data_source_gen.go
+++ b/vantage/datasource_virtual_tag_configs/virtual_tag_configs_data_source_gen.go
@@ -29,6 +29,11 @@ func VirtualTagConfigsDataSourceSchema(ctx context.Context) schema.Schema {
 						"collapsed_tag_keys": schema.ListNestedAttribute{
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
+									"filter": schema.StringAttribute{
+										Computed:            true,
+										Description:         "The VQL filter this collapsed tag key applies to.",
+										MarkdownDescription: "The VQL filter this collapsed tag key applies to.",
+									},
 									"key": schema.StringAttribute{
 										Computed:            true,
 										Description:         "The tag key to collapse values for.",
@@ -37,8 +42,8 @@ func VirtualTagConfigsDataSourceSchema(ctx context.Context) schema.Schema {
 									"providers": schema.ListAttribute{
 										ElementType:         types.StringType,
 										Computed:            true,
-										Description:         "The providers this collapsed tag key applies to. Defaults to all providers.",
-										MarkdownDescription: "The providers this collapsed tag key applies to. Defaults to all providers.",
+										Description:         "The providers this collapsed tag key applies to. Defaults to all providers when omitted.",
+										MarkdownDescription: "The providers this collapsed tag key applies to. Defaults to all providers when omitted.",
 									},
 								},
 								CustomType: CollapsedTagKeysType{
@@ -147,6 +152,40 @@ func VirtualTagConfigsDataSourceSchema(ctx context.Context) schema.Schema {
 										Computed:            true,
 										Description:         "The filter VQL for the Value.",
 										MarkdownDescription: "The filter VQL for the Value.",
+									},
+									"label_transforms": schema.ListNestedAttribute{
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"delimiter": schema.StringAttribute{
+													Computed:            true,
+													Description:         "Delimiter used by split transforms.",
+													MarkdownDescription: "Delimiter used by split transforms.",
+												},
+												"index": schema.Int64Attribute{
+													Computed:            true,
+													Description:         "Zero-based index used by split transforms.",
+													MarkdownDescription: "Zero-based index used by split transforms.",
+												},
+												"template": schema.StringAttribute{
+													Computed:            true,
+													Description:         "Template used by format transforms.",
+													MarkdownDescription: "Template used by format transforms.",
+												},
+												"type": schema.StringAttribute{
+													Computed:            true,
+													Description:         "The label transform type.",
+													MarkdownDescription: "The label transform type.",
+												},
+											},
+											CustomType: LabelTransformsType{
+												ObjectType: types.ObjectType{
+													AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+												},
+											},
+										},
+										Computed:            true,
+										Description:         "Label transforms applied to business metric labels.",
+										MarkdownDescription: "Label transforms applied to business metric labels.",
 									},
 									"name": schema.StringAttribute{
 										Computed:            true,
@@ -1009,6 +1048,24 @@ func (t CollapsedTagKeysType) ValueFromObject(ctx context.Context, in basetypes.
 
 	attributes := in.Attributes()
 
+	filterAttribute, ok := attributes["filter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`filter is missing from object`)
+
+		return nil, diags
+	}
+
+	filterVal, ok := filterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
+	}
+
 	keyAttribute, ok := attributes["key"]
 
 	if !ok {
@@ -1050,6 +1107,7 @@ func (t CollapsedTagKeysType) ValueFromObject(ctx context.Context, in basetypes.
 	}
 
 	return CollapsedTagKeysValue{
+		Filter:    filterVal,
 		Key:       keyVal,
 		Providers: providersVal,
 		state:     attr.ValueStateKnown,
@@ -1119,6 +1177,24 @@ func NewCollapsedTagKeysValue(attributeTypes map[string]attr.Type, attributes ma
 		return NewCollapsedTagKeysValueUnknown(), diags
 	}
 
+	filterAttribute, ok := attributes["filter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`filter is missing from object`)
+
+		return NewCollapsedTagKeysValueUnknown(), diags
+	}
+
+	filterVal, ok := filterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
+	}
+
 	keyAttribute, ok := attributes["key"]
 
 	if !ok {
@@ -1160,6 +1236,7 @@ func NewCollapsedTagKeysValue(attributeTypes map[string]attr.Type, attributes ma
 	}
 
 	return CollapsedTagKeysValue{
+		Filter:    filterVal,
 		Key:       keyVal,
 		Providers: providersVal,
 		state:     attr.ValueStateKnown,
@@ -1234,17 +1311,19 @@ func (t CollapsedTagKeysType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = CollapsedTagKeysValue{}
 
 type CollapsedTagKeysValue struct {
+	Filter    basetypes.StringValue `tfsdk:"filter"`
 	Key       basetypes.StringValue `tfsdk:"key"`
 	Providers basetypes.ListValue   `tfsdk:"providers"`
 	state     attr.ValueState
 }
 
 func (v CollapsedTagKeysValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 2)
+	attrTypes := make(map[string]tftypes.Type, 3)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["filter"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["providers"] = basetypes.ListType{
 		ElemType: types.StringType,
@@ -1254,7 +1333,15 @@ func (v CollapsedTagKeysValue) ToTerraformValue(ctx context.Context) (tftypes.Va
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 2)
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Filter.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["filter"] = val
 
 		val, err = v.Key.ToTerraformValue(ctx)
 
@@ -1315,7 +1402,8 @@ func (v CollapsedTagKeysValue) ToObjectValue(ctx context.Context) (basetypes.Obj
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"key": basetypes.StringType{},
+			"filter": basetypes.StringType{},
+			"key":    basetypes.StringType{},
 			"providers": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -1323,7 +1411,8 @@ func (v CollapsedTagKeysValue) ToObjectValue(ctx context.Context) (basetypes.Obj
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"key": basetypes.StringType{},
+		"filter": basetypes.StringType{},
+		"key":    basetypes.StringType{},
 		"providers": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -1340,6 +1429,7 @@ func (v CollapsedTagKeysValue) ToObjectValue(ctx context.Context) (basetypes.Obj
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
+			"filter":    v.Filter,
 			"key":       v.Key,
 			"providers": providersVal,
 		})
@@ -1360,6 +1450,10 @@ func (v CollapsedTagKeysValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.Filter.Equal(other.Filter) {
+		return false
 	}
 
 	if !v.Key.Equal(other.Key) {
@@ -1383,7 +1477,8 @@ func (v CollapsedTagKeysValue) Type(ctx context.Context) attr.Type {
 
 func (v CollapsedTagKeysValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"key": basetypes.StringType{},
+		"filter": basetypes.StringType{},
+		"key":    basetypes.StringType{},
 		"providers": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -1505,6 +1600,24 @@ func (t ValuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
 	}
 
+	labelTransformsAttribute, ok := attributes["label_transforms"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_transforms is missing from object`)
+
+		return nil, diags
+	}
+
+	labelTransformsVal, ok := labelTransformsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_transforms expected to be basetypes.ListValue, was: %T`, labelTransformsAttribute))
+	}
+
 	nameAttribute, ok := attributes["name"]
 
 	if !ok {
@@ -1551,6 +1664,7 @@ func (t ValuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		DateRanges:          dateRangesVal,
 		DisplayName:         displayNameVal,
 		Filter:              filterVal,
+		LabelTransforms:     labelTransformsVal,
 		Name:                nameVal,
 		Percentages:         percentagesVal,
 		state:               attr.ValueStateKnown,
@@ -1710,6 +1824,24 @@ func NewValuesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
 	}
 
+	labelTransformsAttribute, ok := attributes["label_transforms"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_transforms is missing from object`)
+
+		return NewValuesValueUnknown(), diags
+	}
+
+	labelTransformsVal, ok := labelTransformsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_transforms expected to be basetypes.ListValue, was: %T`, labelTransformsAttribute))
+	}
+
 	nameAttribute, ok := attributes["name"]
 
 	if !ok {
@@ -1756,6 +1888,7 @@ func NewValuesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		DateRanges:          dateRangesVal,
 		DisplayName:         displayNameVal,
 		Filter:              filterVal,
+		LabelTransforms:     labelTransformsVal,
 		Name:                nameVal,
 		Percentages:         percentagesVal,
 		state:               attr.ValueStateKnown,
@@ -1835,13 +1968,14 @@ type ValuesValue struct {
 	DateRanges          basetypes.ListValue   `tfsdk:"date_ranges"`
 	DisplayName         basetypes.StringValue `tfsdk:"display_name"`
 	Filter              basetypes.StringValue `tfsdk:"filter"`
+	LabelTransforms     basetypes.ListValue   `tfsdk:"label_transforms"`
 	Name                basetypes.StringValue `tfsdk:"name"`
 	Percentages         basetypes.ListValue   `tfsdk:"percentages"`
 	state               attr.ValueState
 }
 
 func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 7)
+	attrTypes := make(map[string]tftypes.Type, 8)
 
 	var val tftypes.Value
 	var err error
@@ -1855,6 +1989,9 @@ func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 	}.TerraformType(ctx)
 	attrTypes["display_name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["filter"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["label_transforms"] = basetypes.ListType{
+		ElemType: LabelTransformsValue{}.Type(ctx),
+	}.TerraformType(ctx)
 	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["percentages"] = basetypes.ListType{
 		ElemType: PercentagesValue{}.Type(ctx),
@@ -1864,7 +2001,7 @@ func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 7)
+		vals := make(map[string]tftypes.Value, 8)
 
 		val, err = v.BusinessMetricToken.ToTerraformValue(ctx)
 
@@ -1905,6 +2042,14 @@ func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 		}
 
 		vals["filter"] = val
+
+		val, err = v.LabelTransforms.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["label_transforms"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
 
@@ -2001,6 +2146,35 @@ func (v ValuesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		)
 	}
 
+	labelTransforms := types.ListValueMust(
+		LabelTransformsType{
+			basetypes.ObjectType{
+				AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+			},
+		},
+		v.LabelTransforms.Elements(),
+	)
+
+	if v.LabelTransforms.IsNull() {
+		labelTransforms = types.ListNull(
+			LabelTransformsType{
+				basetypes.ObjectType{
+					AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
+	if v.LabelTransforms.IsUnknown() {
+		labelTransforms = types.ListUnknown(
+			LabelTransformsType{
+				basetypes.ObjectType{
+					AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
 	percentages := types.ListValueMust(
 		PercentagesType{
 			basetypes.ObjectType{
@@ -2040,7 +2214,10 @@ func (v ValuesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		},
 		"display_name": basetypes.StringType{},
 		"filter":       basetypes.StringType{},
-		"name":         basetypes.StringType{},
+		"label_transforms": basetypes.ListType{
+			ElemType: LabelTransformsValue{}.Type(ctx),
+		},
+		"name": basetypes.StringType{},
 		"percentages": basetypes.ListType{
 			ElemType: PercentagesValue{}.Type(ctx),
 		},
@@ -2062,6 +2239,7 @@ func (v ValuesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 			"date_ranges":           dateRanges,
 			"display_name":          v.DisplayName,
 			"filter":                v.Filter,
+			"label_transforms":      labelTransforms,
 			"name":                  v.Name,
 			"percentages":           percentages,
 		})
@@ -2104,6 +2282,10 @@ func (v ValuesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.LabelTransforms.Equal(other.LabelTransforms) {
+		return false
+	}
+
 	if !v.Name.Equal(other.Name) {
 		return false
 	}
@@ -2134,7 +2316,10 @@ func (v ValuesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		},
 		"display_name": basetypes.StringType{},
 		"filter":       basetypes.StringType{},
-		"name":         basetypes.StringType{},
+		"label_transforms": basetypes.ListType{
+			ElemType: LabelTransformsValue{}.Type(ctx),
+		},
+		"name": basetypes.StringType{},
 		"percentages": basetypes.ListType{
 			ElemType: PercentagesValue{}.Type(ctx),
 		},
@@ -3247,6 +3432,495 @@ func (v DateRangesValue) AttributeTypes(ctx context.Context) map[string]attr.Typ
 	return map[string]attr.Type{
 		"end_date":   basetypes.StringType{},
 		"start_date": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = LabelTransformsType{}
+
+type LabelTransformsType struct {
+	basetypes.ObjectType
+}
+
+func (t LabelTransformsType) Equal(o attr.Type) bool {
+	other, ok := o.(LabelTransformsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t LabelTransformsType) String() string {
+	return "LabelTransformsType"
+}
+
+func (t LabelTransformsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	delimiterAttribute, ok := attributes["delimiter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`delimiter is missing from object`)
+
+		return nil, diags
+	}
+
+	delimiterVal, ok := delimiterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`delimiter expected to be basetypes.StringValue, was: %T`, delimiterAttribute))
+	}
+
+	indexAttribute, ok := attributes["index"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`index is missing from object`)
+
+		return nil, diags
+	}
+
+	indexVal, ok := indexAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`index expected to be basetypes.Int64Value, was: %T`, indexAttribute))
+	}
+
+	templateAttribute, ok := attributes["template"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`template is missing from object`)
+
+		return nil, diags
+	}
+
+	templateVal, ok := templateAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`template expected to be basetypes.StringValue, was: %T`, templateAttribute))
+	}
+
+	typeAttribute, ok := attributes["type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`type is missing from object`)
+
+		return nil, diags
+	}
+
+	typeVal, ok := typeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`type expected to be basetypes.StringValue, was: %T`, typeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return LabelTransformsValue{
+		Delimiter:           delimiterVal,
+		Index:               indexVal,
+		Template:            templateVal,
+		LabelTransformsType: typeVal,
+		state:               attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelTransformsValueNull() LabelTransformsValue {
+	return LabelTransformsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewLabelTransformsValueUnknown() LabelTransformsValue {
+	return LabelTransformsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewLabelTransformsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (LabelTransformsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing LabelTransformsValue Attribute Value",
+				"While creating a LabelTransformsValue value, a missing attribute value was detected. "+
+					"A LabelTransformsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelTransformsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid LabelTransformsValue Attribute Type",
+				"While creating a LabelTransformsValue value, an invalid attribute value was detected. "+
+					"A LabelTransformsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelTransformsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("LabelTransformsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra LabelTransformsValue Attribute Value",
+				"While creating a LabelTransformsValue value, an extra attribute value was detected. "+
+					"A LabelTransformsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra LabelTransformsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	delimiterAttribute, ok := attributes["delimiter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`delimiter is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	delimiterVal, ok := delimiterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`delimiter expected to be basetypes.StringValue, was: %T`, delimiterAttribute))
+	}
+
+	indexAttribute, ok := attributes["index"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`index is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	indexVal, ok := indexAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`index expected to be basetypes.Int64Value, was: %T`, indexAttribute))
+	}
+
+	templateAttribute, ok := attributes["template"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`template is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	templateVal, ok := templateAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`template expected to be basetypes.StringValue, was: %T`, templateAttribute))
+	}
+
+	typeAttribute, ok := attributes["type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`type is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	typeVal, ok := typeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`type expected to be basetypes.StringValue, was: %T`, typeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	return LabelTransformsValue{
+		Delimiter:           delimiterVal,
+		Index:               indexVal,
+		Template:            templateVal,
+		LabelTransformsType: typeVal,
+		state:               attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelTransformsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) LabelTransformsValue {
+	object, diags := NewLabelTransformsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewLabelTransformsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t LabelTransformsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewLabelTransformsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewLabelTransformsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewLabelTransformsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewLabelTransformsValueMust(LabelTransformsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t LabelTransformsType) ValueType(ctx context.Context) attr.Value {
+	return LabelTransformsValue{}
+}
+
+var _ basetypes.ObjectValuable = LabelTransformsValue{}
+
+type LabelTransformsValue struct {
+	Delimiter           basetypes.StringValue `tfsdk:"delimiter"`
+	Index               basetypes.Int64Value  `tfsdk:"index"`
+	Template            basetypes.StringValue `tfsdk:"template"`
+	LabelTransformsType basetypes.StringValue `tfsdk:"type"`
+	state               attr.ValueState
+}
+
+func (v LabelTransformsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 4)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["delimiter"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["index"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["template"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 4)
+
+		val, err = v.Delimiter.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["delimiter"] = val
+
+		val, err = v.Index.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["index"] = val
+
+		val, err = v.Template.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["template"] = val
+
+		val, err = v.LabelTransformsType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v LabelTransformsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v LabelTransformsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v LabelTransformsValue) String() string {
+	return "LabelTransformsValue"
+}
+
+func (v LabelTransformsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"delimiter": basetypes.StringType{},
+		"index":     basetypes.Int64Type{},
+		"template":  basetypes.StringType{},
+		"type":      basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"delimiter": v.Delimiter,
+			"index":     v.Index,
+			"template":  v.Template,
+			"type":      v.LabelTransformsType,
+		})
+
+	return objVal, diags
+}
+
+func (v LabelTransformsValue) Equal(o attr.Value) bool {
+	other, ok := o.(LabelTransformsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Delimiter.Equal(other.Delimiter) {
+		return false
+	}
+
+	if !v.Index.Equal(other.Index) {
+		return false
+	}
+
+	if !v.Template.Equal(other.Template) {
+		return false
+	}
+
+	if !v.LabelTransformsType.Equal(other.LabelTransformsType) {
+		return false
+	}
+
+	return true
+}
+
+func (v LabelTransformsValue) Type(ctx context.Context) attr.Type {
+	return LabelTransformsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v LabelTransformsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"delimiter": basetypes.StringType{},
+		"index":     basetypes.Int64Type{},
+		"template":  basetypes.StringType{},
+		"type":      basetypes.StringType{},
 	}
 }
 

--- a/vantage/resource_virtual_tag_config/virtual_tag_config_resource_gen.go
+++ b/vantage/resource_virtual_tag_config/virtual_tag_config_resource_gen.go
@@ -27,6 +27,12 @@ func VirtualTagConfigResourceSchema(ctx context.Context) schema.Schema {
 			"collapsed_tag_keys": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"filter": schema.StringAttribute{
+							Optional:            true,
+							Computed:            true,
+							Description:         "The VQL filter this collapsed tag key applies to.",
+							MarkdownDescription: "The VQL filter this collapsed tag key applies to.",
+						},
 						"key": schema.StringAttribute{
 							Required:            true,
 							Description:         "The tag key to collapse values for.",
@@ -154,6 +160,44 @@ func VirtualTagConfigResourceSchema(ctx context.Context) schema.Schema {
 							Description:         "The filter query language to apply to the value. Additional documentation available at https://docs.vantage.sh/vql.",
 							MarkdownDescription: "The filter query language to apply to the value. Additional documentation available at https://docs.vantage.sh/vql.",
 						},
+						"label_transforms": schema.ListNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"delimiter": schema.StringAttribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "Delimiter used by split transforms.",
+										MarkdownDescription: "Delimiter used by split transforms.",
+									},
+									"index": schema.Int64Attribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "Zero-based index used by split transforms.",
+										MarkdownDescription: "Zero-based index used by split transforms.",
+									},
+									"template": schema.StringAttribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "Template used by format transforms.",
+										MarkdownDescription: "Template used by format transforms.",
+									},
+									"type": schema.StringAttribute{
+										Required:            true,
+										Description:         "The label transform type.",
+										MarkdownDescription: "The label transform type.",
+									},
+								},
+								CustomType: LabelTransformsType{
+									ObjectType: types.ObjectType{
+										AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+									},
+								},
+							},
+							Optional:            true,
+							Computed:            true,
+							Description:         "Label transforms applied to business metric labels.",
+							MarkdownDescription: "Label transforms applied to business metric labels.",
+						},
 						"name": schema.StringAttribute{
 							Optional:            true,
 							Computed:            true,
@@ -235,6 +279,24 @@ func (t CollapsedTagKeysType) ValueFromObject(ctx context.Context, in basetypes.
 
 	attributes := in.Attributes()
 
+	filterAttribute, ok := attributes["filter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`filter is missing from object`)
+
+		return nil, diags
+	}
+
+	filterVal, ok := filterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
+	}
+
 	keyAttribute, ok := attributes["key"]
 
 	if !ok {
@@ -276,6 +338,7 @@ func (t CollapsedTagKeysType) ValueFromObject(ctx context.Context, in basetypes.
 	}
 
 	return CollapsedTagKeysValue{
+		Filter:    filterVal,
 		Key:       keyVal,
 		Providers: providersVal,
 		state:     attr.ValueStateKnown,
@@ -345,6 +408,24 @@ func NewCollapsedTagKeysValue(attributeTypes map[string]attr.Type, attributes ma
 		return NewCollapsedTagKeysValueUnknown(), diags
 	}
 
+	filterAttribute, ok := attributes["filter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`filter is missing from object`)
+
+		return NewCollapsedTagKeysValueUnknown(), diags
+	}
+
+	filterVal, ok := filterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
+	}
+
 	keyAttribute, ok := attributes["key"]
 
 	if !ok {
@@ -386,6 +467,7 @@ func NewCollapsedTagKeysValue(attributeTypes map[string]attr.Type, attributes ma
 	}
 
 	return CollapsedTagKeysValue{
+		Filter:    filterVal,
 		Key:       keyVal,
 		Providers: providersVal,
 		state:     attr.ValueStateKnown,
@@ -460,17 +542,19 @@ func (t CollapsedTagKeysType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = CollapsedTagKeysValue{}
 
 type CollapsedTagKeysValue struct {
+	Filter    basetypes.StringValue `tfsdk:"filter"`
 	Key       basetypes.StringValue `tfsdk:"key"`
 	Providers basetypes.ListValue   `tfsdk:"providers"`
 	state     attr.ValueState
 }
 
 func (v CollapsedTagKeysValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 2)
+	attrTypes := make(map[string]tftypes.Type, 3)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["filter"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["providers"] = basetypes.ListType{
 		ElemType: types.StringType,
@@ -480,7 +564,15 @@ func (v CollapsedTagKeysValue) ToTerraformValue(ctx context.Context) (tftypes.Va
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 2)
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Filter.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["filter"] = val
 
 		val, err = v.Key.ToTerraformValue(ctx)
 
@@ -541,7 +633,8 @@ func (v CollapsedTagKeysValue) ToObjectValue(ctx context.Context) (basetypes.Obj
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"key": basetypes.StringType{},
+			"filter": basetypes.StringType{},
+			"key":    basetypes.StringType{},
 			"providers": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -549,7 +642,8 @@ func (v CollapsedTagKeysValue) ToObjectValue(ctx context.Context) (basetypes.Obj
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"key": basetypes.StringType{},
+		"filter": basetypes.StringType{},
+		"key":    basetypes.StringType{},
 		"providers": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -566,6 +660,7 @@ func (v CollapsedTagKeysValue) ToObjectValue(ctx context.Context) (basetypes.Obj
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
+			"filter":    v.Filter,
 			"key":       v.Key,
 			"providers": providersVal,
 		})
@@ -586,6 +681,10 @@ func (v CollapsedTagKeysValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.Filter.Equal(other.Filter) {
+		return false
 	}
 
 	if !v.Key.Equal(other.Key) {
@@ -609,7 +708,8 @@ func (v CollapsedTagKeysValue) Type(ctx context.Context) attr.Type {
 
 func (v CollapsedTagKeysValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"key": basetypes.StringType{},
+		"filter": basetypes.StringType{},
+		"key":    basetypes.StringType{},
 		"providers": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -731,6 +831,24 @@ func (t ValuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
 	}
 
+	labelTransformsAttribute, ok := attributes["label_transforms"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_transforms is missing from object`)
+
+		return nil, diags
+	}
+
+	labelTransformsVal, ok := labelTransformsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_transforms expected to be basetypes.ListValue, was: %T`, labelTransformsAttribute))
+	}
+
 	nameAttribute, ok := attributes["name"]
 
 	if !ok {
@@ -777,6 +895,7 @@ func (t ValuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		DateRanges:          dateRangesVal,
 		DisplayName:         displayNameVal,
 		Filter:              filterVal,
+		LabelTransforms:     labelTransformsVal,
 		Name:                nameVal,
 		Percentages:         percentagesVal,
 		state:               attr.ValueStateKnown,
@@ -936,6 +1055,24 @@ func NewValuesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 			fmt.Sprintf(`filter expected to be basetypes.StringValue, was: %T`, filterAttribute))
 	}
 
+	labelTransformsAttribute, ok := attributes["label_transforms"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_transforms is missing from object`)
+
+		return NewValuesValueUnknown(), diags
+	}
+
+	labelTransformsVal, ok := labelTransformsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_transforms expected to be basetypes.ListValue, was: %T`, labelTransformsAttribute))
+	}
+
 	nameAttribute, ok := attributes["name"]
 
 	if !ok {
@@ -982,6 +1119,7 @@ func NewValuesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		DateRanges:          dateRangesVal,
 		DisplayName:         displayNameVal,
 		Filter:              filterVal,
+		LabelTransforms:     labelTransformsVal,
 		Name:                nameVal,
 		Percentages:         percentagesVal,
 		state:               attr.ValueStateKnown,
@@ -1061,13 +1199,14 @@ type ValuesValue struct {
 	DateRanges          basetypes.ListValue   `tfsdk:"date_ranges"`
 	DisplayName         basetypes.StringValue `tfsdk:"display_name"`
 	Filter              basetypes.StringValue `tfsdk:"filter"`
+	LabelTransforms     basetypes.ListValue   `tfsdk:"label_transforms"`
 	Name                basetypes.StringValue `tfsdk:"name"`
 	Percentages         basetypes.ListValue   `tfsdk:"percentages"`
 	state               attr.ValueState
 }
 
 func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 7)
+	attrTypes := make(map[string]tftypes.Type, 8)
 
 	var val tftypes.Value
 	var err error
@@ -1081,6 +1220,9 @@ func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 	}.TerraformType(ctx)
 	attrTypes["display_name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["filter"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["label_transforms"] = basetypes.ListType{
+		ElemType: LabelTransformsValue{}.Type(ctx),
+	}.TerraformType(ctx)
 	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["percentages"] = basetypes.ListType{
 		ElemType: PercentagesValue{}.Type(ctx),
@@ -1090,7 +1232,7 @@ func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 7)
+		vals := make(map[string]tftypes.Value, 8)
 
 		val, err = v.BusinessMetricToken.ToTerraformValue(ctx)
 
@@ -1131,6 +1273,14 @@ func (v ValuesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 		}
 
 		vals["filter"] = val
+
+		val, err = v.LabelTransforms.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["label_transforms"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
 
@@ -1227,6 +1377,35 @@ func (v ValuesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		)
 	}
 
+	labelTransforms := types.ListValueMust(
+		LabelTransformsType{
+			basetypes.ObjectType{
+				AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+			},
+		},
+		v.LabelTransforms.Elements(),
+	)
+
+	if v.LabelTransforms.IsNull() {
+		labelTransforms = types.ListNull(
+			LabelTransformsType{
+				basetypes.ObjectType{
+					AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
+	if v.LabelTransforms.IsUnknown() {
+		labelTransforms = types.ListUnknown(
+			LabelTransformsType{
+				basetypes.ObjectType{
+					AttrTypes: LabelTransformsValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
 	percentages := types.ListValueMust(
 		PercentagesType{
 			basetypes.ObjectType{
@@ -1266,7 +1445,10 @@ func (v ValuesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		},
 		"display_name": basetypes.StringType{},
 		"filter":       basetypes.StringType{},
-		"name":         basetypes.StringType{},
+		"label_transforms": basetypes.ListType{
+			ElemType: LabelTransformsValue{}.Type(ctx),
+		},
+		"name": basetypes.StringType{},
 		"percentages": basetypes.ListType{
 			ElemType: PercentagesValue{}.Type(ctx),
 		},
@@ -1288,6 +1470,7 @@ func (v ValuesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 			"date_ranges":           dateRanges,
 			"display_name":          v.DisplayName,
 			"filter":                v.Filter,
+			"label_transforms":      labelTransforms,
 			"name":                  v.Name,
 			"percentages":           percentages,
 		})
@@ -1330,6 +1513,10 @@ func (v ValuesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.LabelTransforms.Equal(other.LabelTransforms) {
+		return false
+	}
+
 	if !v.Name.Equal(other.Name) {
 		return false
 	}
@@ -1360,7 +1547,10 @@ func (v ValuesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		},
 		"display_name": basetypes.StringType{},
 		"filter":       basetypes.StringType{},
-		"name":         basetypes.StringType{},
+		"label_transforms": basetypes.ListType{
+			ElemType: LabelTransformsValue{}.Type(ctx),
+		},
+		"name": basetypes.StringType{},
 		"percentages": basetypes.ListType{
 			ElemType: PercentagesValue{}.Type(ctx),
 		},
@@ -2473,6 +2663,495 @@ func (v DateRangesValue) AttributeTypes(ctx context.Context) map[string]attr.Typ
 	return map[string]attr.Type{
 		"end_date":   basetypes.StringType{},
 		"start_date": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = LabelTransformsType{}
+
+type LabelTransformsType struct {
+	basetypes.ObjectType
+}
+
+func (t LabelTransformsType) Equal(o attr.Type) bool {
+	other, ok := o.(LabelTransformsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t LabelTransformsType) String() string {
+	return "LabelTransformsType"
+}
+
+func (t LabelTransformsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	delimiterAttribute, ok := attributes["delimiter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`delimiter is missing from object`)
+
+		return nil, diags
+	}
+
+	delimiterVal, ok := delimiterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`delimiter expected to be basetypes.StringValue, was: %T`, delimiterAttribute))
+	}
+
+	indexAttribute, ok := attributes["index"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`index is missing from object`)
+
+		return nil, diags
+	}
+
+	indexVal, ok := indexAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`index expected to be basetypes.Int64Value, was: %T`, indexAttribute))
+	}
+
+	templateAttribute, ok := attributes["template"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`template is missing from object`)
+
+		return nil, diags
+	}
+
+	templateVal, ok := templateAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`template expected to be basetypes.StringValue, was: %T`, templateAttribute))
+	}
+
+	typeAttribute, ok := attributes["type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`type is missing from object`)
+
+		return nil, diags
+	}
+
+	typeVal, ok := typeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`type expected to be basetypes.StringValue, was: %T`, typeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return LabelTransformsValue{
+		Delimiter:           delimiterVal,
+		Index:               indexVal,
+		Template:            templateVal,
+		LabelTransformsType: typeVal,
+		state:               attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelTransformsValueNull() LabelTransformsValue {
+	return LabelTransformsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewLabelTransformsValueUnknown() LabelTransformsValue {
+	return LabelTransformsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewLabelTransformsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (LabelTransformsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing LabelTransformsValue Attribute Value",
+				"While creating a LabelTransformsValue value, a missing attribute value was detected. "+
+					"A LabelTransformsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelTransformsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid LabelTransformsValue Attribute Type",
+				"While creating a LabelTransformsValue value, an invalid attribute value was detected. "+
+					"A LabelTransformsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelTransformsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("LabelTransformsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra LabelTransformsValue Attribute Value",
+				"While creating a LabelTransformsValue value, an extra attribute value was detected. "+
+					"A LabelTransformsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra LabelTransformsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	delimiterAttribute, ok := attributes["delimiter"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`delimiter is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	delimiterVal, ok := delimiterAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`delimiter expected to be basetypes.StringValue, was: %T`, delimiterAttribute))
+	}
+
+	indexAttribute, ok := attributes["index"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`index is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	indexVal, ok := indexAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`index expected to be basetypes.Int64Value, was: %T`, indexAttribute))
+	}
+
+	templateAttribute, ok := attributes["template"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`template is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	templateVal, ok := templateAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`template expected to be basetypes.StringValue, was: %T`, templateAttribute))
+	}
+
+	typeAttribute, ok := attributes["type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`type is missing from object`)
+
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	typeVal, ok := typeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`type expected to be basetypes.StringValue, was: %T`, typeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewLabelTransformsValueUnknown(), diags
+	}
+
+	return LabelTransformsValue{
+		Delimiter:           delimiterVal,
+		Index:               indexVal,
+		Template:            templateVal,
+		LabelTransformsType: typeVal,
+		state:               attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelTransformsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) LabelTransformsValue {
+	object, diags := NewLabelTransformsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewLabelTransformsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t LabelTransformsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewLabelTransformsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewLabelTransformsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewLabelTransformsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewLabelTransformsValueMust(LabelTransformsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t LabelTransformsType) ValueType(ctx context.Context) attr.Value {
+	return LabelTransformsValue{}
+}
+
+var _ basetypes.ObjectValuable = LabelTransformsValue{}
+
+type LabelTransformsValue struct {
+	Delimiter           basetypes.StringValue `tfsdk:"delimiter"`
+	Index               basetypes.Int64Value  `tfsdk:"index"`
+	Template            basetypes.StringValue `tfsdk:"template"`
+	LabelTransformsType basetypes.StringValue `tfsdk:"type"`
+	state               attr.ValueState
+}
+
+func (v LabelTransformsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 4)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["delimiter"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["index"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["template"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 4)
+
+		val, err = v.Delimiter.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["delimiter"] = val
+
+		val, err = v.Index.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["index"] = val
+
+		val, err = v.Template.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["template"] = val
+
+		val, err = v.LabelTransformsType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v LabelTransformsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v LabelTransformsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v LabelTransformsValue) String() string {
+	return "LabelTransformsValue"
+}
+
+func (v LabelTransformsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"delimiter": basetypes.StringType{},
+		"index":     basetypes.Int64Type{},
+		"template":  basetypes.StringType{},
+		"type":      basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"delimiter": v.Delimiter,
+			"index":     v.Index,
+			"template":  v.Template,
+			"type":      v.LabelTransformsType,
+		})
+
+	return objVal, diags
+}
+
+func (v LabelTransformsValue) Equal(o attr.Value) bool {
+	other, ok := o.(LabelTransformsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Delimiter.Equal(other.Delimiter) {
+		return false
+	}
+
+	if !v.Index.Equal(other.Index) {
+		return false
+	}
+
+	if !v.Template.Equal(other.Template) {
+		return false
+	}
+
+	if !v.LabelTransformsType.Equal(other.LabelTransformsType) {
+		return false
+	}
+
+	return true
+}
+
+func (v LabelTransformsValue) Type(ctx context.Context) attr.Type {
+	return LabelTransformsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v LabelTransformsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"delimiter": basetypes.StringType{},
+		"index":     basetypes.Int64Type{},
+		"template":  basetypes.StringType{},
+		"type":      basetypes.StringType{},
 	}
 }
 

--- a/vantage/virtual_tag_config_resource.go
+++ b/vantage/virtual_tag_config_resource.go
@@ -65,6 +65,7 @@ func (r VirtualTagConfigResource) Schema(ctx context.Context, req resource.Schem
 				"date_ranges":           generatedValuesAttrs["date_ranges"],
 				"display_name":          generatedValuesAttrs["display_name"],
 				"filter":                generatedValuesAttrs["filter"],
+				"label_transforms":      generatedValuesAttrs["label_transforms"],
 				"name":                  generatedValuesAttrs["name"],
 				"percentages":           generatedValuesAttrs["percentages"],
 				// Override cost_metric: make aggregation, aggregation.tag, and filter Optional

--- a/vantage/virtual_tag_config_resource_model.go
+++ b/vantage/virtual_tag_config_resource_model.go
@@ -20,6 +20,7 @@ type virtualTagConfigValueModel struct {
 	DateRanges          types.List                                  `tfsdk:"date_ranges"`
 	DisplayName         types.String                                `tfsdk:"display_name"`
 	Filter              types.String                                `tfsdk:"filter"`
+	LabelTransforms     types.List                                  `tfsdk:"label_transforms"`
 	Name                types.String                                `tfsdk:"name"`
 	Percentages         types.List                                  `tfsdk:"percentages"`
 }
@@ -29,6 +30,7 @@ type virtualTagConfigValueModel struct {
 // Terraform state is identical.
 
 type collapsedTagKeyData struct {
+	Filter    *string
 	Key       *string
 	Providers []string
 }
@@ -41,6 +43,13 @@ type percentageData struct {
 type dateRangeData struct {
 	StartDate string
 	EndDate   string
+}
+
+type labelTransformData struct {
+	Type      string
+	Delimiter *string
+	Index     *int32
+	Template  *string
 }
 
 type aggregationData struct {
@@ -59,6 +68,7 @@ type valueData struct {
 	BusinessMetricToken string
 	CostMetric          *costMetricData
 	DateRanges          []dateRangeData
+	LabelTransforms     []labelTransformData
 	Percentages         []percentageData
 }
 
@@ -109,6 +119,30 @@ func buildPercentagesFromPayload(ctx context.Context, percentages []*modelsv2.Vi
 		tfPercentages = append(tfPercentages, pv)
 	}
 	return types.ListValueFrom(ctx, resource_virtual_tag_config.PercentagesValue{}.Type(ctx), tfPercentages)
+}
+
+func buildLabelTransformsFromPayload(ctx context.Context, labelTransforms []*modelsv2.VirtualTagConfigValueLabelTransform) (basetypes.ListValue, diag.Diagnostics) {
+	tfLabelTransforms := make([]resource_virtual_tag_config.LabelTransformsValue, 0, len(labelTransforms))
+	for _, lt := range labelTransforms {
+		var indexValue attr.Value = types.Int64Null()
+		if lt.Index != nil {
+			indexValue = types.Int64Value(int64(*lt.Index))
+		}
+		ltv, d := resource_virtual_tag_config.NewLabelTransformsValue(
+			resource_virtual_tag_config.LabelTransformsValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"type":      types.StringValue(lt.Type),
+				"delimiter": types.StringPointerValue(lt.Delimiter),
+				"index":     indexValue,
+				"template":  types.StringPointerValue(lt.Template),
+			},
+		)
+		if d.HasError() {
+			return basetypes.ListValue{}, d
+		}
+		tfLabelTransforms = append(tfLabelTransforms, ltv)
+	}
+	return types.ListValueFrom(ctx, resource_virtual_tag_config.LabelTransformsValue{}.Type(ctx), tfLabelTransforms)
 }
 
 func buildDateRangesFromPayload(ctx context.Context, dateRanges []*modelsv2.VirtualTagConfigValueDateRange) (basetypes.ListValue, diag.Diagnostics) {
@@ -190,6 +224,20 @@ func buildValueFromPayload(ctx context.Context, v *modelsv2.VirtualTagConfigValu
 		dateRangesValue = dateRanges
 	}
 
+	// Build label_transforms value
+	var labelTransformsValue attr.Value = types.ListNull(resource_virtual_tag_config.LabelTransformsType{
+		ObjectType: basetypes.ObjectType{
+			AttrTypes: resource_virtual_tag_config.LabelTransformsValue{}.AttributeTypes(ctx),
+		},
+	})
+	if len(v.LabelTransforms) > 0 {
+		labelTransforms, d := buildLabelTransformsFromPayload(ctx, v.LabelTransforms)
+		if d.HasError() {
+			return basetypes.ObjectValue{}, d
+		}
+		labelTransformsValue = labelTransforms
+	}
+
 	// Use the constructor to properly set the state field
 	value, diags := resource_virtual_tag_config.NewValuesValue(
 		resource_virtual_tag_config.ValuesValue{}.AttributeTypes(ctx),
@@ -200,6 +248,7 @@ func buildValueFromPayload(ctx context.Context, v *modelsv2.VirtualTagConfigValu
 			"cost_metric":           costMetricValue,
 			"date_ranges":           dateRangesValue,
 			"display_name":          displayNameValue,
+			"label_transforms":      labelTransformsValue,
 			"percentages":           percentagesValue,
 		},
 	)
@@ -227,6 +276,7 @@ func (m *virtualTagConfigModel) applyPayload(ctx context.Context, payload *model
 		collapsedTagKey, diag := resource_virtual_tag_config.NewCollapsedTagKeysValue(
 			resource_virtual_tag_config.CollapsedTagKeysValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
+				"filter":    types.StringPointerValue(c.Filter),
 				"key":       types.StringValue(c.Key),
 				"providers": tfProviders,
 			},
@@ -283,10 +333,14 @@ func (m *virtualTagConfigModel) toCreate(ctx context.Context, diags *diag.Diagno
 		}
 		model.CollapsedTagKeys = make([]*modelsv2.CreateVirtualTagConfigCollapsedTagKeysItems0, 0, len(collapsedTagKeys))
 		for _, c := range collapsedTagKeys {
-			model.CollapsedTagKeys = append(model.CollapsedTagKeys, &modelsv2.CreateVirtualTagConfigCollapsedTagKeysItems0{
+			item := &modelsv2.CreateVirtualTagConfigCollapsedTagKeysItems0{
 				Key:       c.Key,
 				Providers: c.Providers,
-			})
+			}
+			if c.Filter != nil {
+				item.Filter = *c.Filter
+			}
+			model.CollapsedTagKeys = append(model.CollapsedTagKeys, item)
 		}
 	}
 
@@ -341,6 +395,26 @@ func (m *virtualTagConfigModel) toCreate(ctx context.Context, diags *diag.Diagno
 				}
 			}
 
+			if len(data.LabelTransforms) > 0 {
+				value.LabelTransforms = make([]*modelsv2.CreateVirtualTagConfigValuesItems0LabelTransformsItems0, 0, len(data.LabelTransforms))
+				for _, lt := range data.LabelTransforms {
+					ltType := lt.Type
+					item := &modelsv2.CreateVirtualTagConfigValuesItems0LabelTransformsItems0{
+						Type: &ltType,
+					}
+					if lt.Delimiter != nil {
+						item.Delimiter = *lt.Delimiter
+					}
+					if lt.Index != nil {
+						item.Index = *lt.Index
+					}
+					if lt.Template != nil {
+						item.Template = *lt.Template
+					}
+					value.LabelTransforms = append(value.LabelTransforms, item)
+				}
+			}
+
 			model.Values = append(model.Values, value)
 		}
 	}
@@ -377,10 +451,14 @@ func (m *virtualTagConfigModel) toUpdate(ctx context.Context, diags *diag.Diagno
 		}
 		model.CollapsedTagKeys = make([]*modelsv2.UpdateVirtualTagConfigCollapsedTagKeysItems0, 0, len(collapsedTagKeys))
 		for _, c := range collapsedTagKeys {
-			model.CollapsedTagKeys = append(model.CollapsedTagKeys, &modelsv2.UpdateVirtualTagConfigCollapsedTagKeysItems0{
+			item := &modelsv2.UpdateVirtualTagConfigCollapsedTagKeysItems0{
 				Key:       c.Key,
 				Providers: c.Providers,
-			})
+			}
+			if c.Filter != nil {
+				item.Filter = *c.Filter
+			}
+			model.CollapsedTagKeys = append(model.CollapsedTagKeys, item)
 		}
 	}
 
@@ -436,6 +514,26 @@ func (m *virtualTagConfigModel) toUpdate(ctx context.Context, diags *diag.Diagno
 				}
 			}
 
+			if len(data.LabelTransforms) > 0 {
+				value.LabelTransforms = make([]*modelsv2.UpdateVirtualTagConfigValuesItems0LabelTransformsItems0, 0, len(data.LabelTransforms))
+				for _, lt := range data.LabelTransforms {
+					ltType := lt.Type
+					item := &modelsv2.UpdateVirtualTagConfigValuesItems0LabelTransformsItems0{
+						Type: &ltType,
+					}
+					if lt.Delimiter != nil {
+						item.Delimiter = *lt.Delimiter
+					}
+					if lt.Index != nil {
+						item.Index = *lt.Index
+					}
+					if lt.Template != nil {
+						item.Template = *lt.Template
+					}
+					value.LabelTransforms = append(value.LabelTransforms, item)
+				}
+			}
+
 			model.Values = append(model.Values, value)
 		}
 	}
@@ -484,6 +582,7 @@ func (m *virtualTagConfigModel) collapsedTagKeysFromTf(ctx context.Context, diag
 			}
 		}
 		result = append(result, collapsedTagKeyData{
+			Filter:    c.Filter.ValueStringPointer(),
 			Key:       c.Key.ValueStringPointer(),
 			Providers: providers,
 		})
@@ -542,6 +641,28 @@ func (v *virtualTagConfigValueModel) toValueData(ctx context.Context, diags *dia
 				StartDate: dr.StartDate.ValueString(),
 				EndDate:   dr.EndDate.ValueString(),
 			})
+		}
+	}
+
+	if !v.LabelTransforms.IsNull() && !v.LabelTransforms.IsUnknown() {
+		tfLabelTransforms := make([]resource_virtual_tag_config.LabelTransformsValue, 0, len(v.LabelTransforms.Elements()))
+		if d := v.LabelTransforms.ElementsAs(ctx, &tfLabelTransforms, false); d.HasError() {
+			diags.Append(d...)
+			return nil
+		}
+		data.LabelTransforms = make([]labelTransformData, 0, len(tfLabelTransforms))
+		for _, lt := range tfLabelTransforms {
+			lt := lt
+			item := labelTransformData{
+				Type:      lt.LabelTransformsType.ValueString(),
+				Delimiter: lt.Delimiter.ValueStringPointer(),
+				Template:  lt.Template.ValueStringPointer(),
+			}
+			if !lt.Index.IsNull() && !lt.Index.IsUnknown() {
+				idx := int32(lt.Index.ValueInt64())
+				item.Index = &idx
+			}
+			data.LabelTransforms = append(data.LabelTransforms, item)
 		}
 	}
 

--- a/vantage/virtual_tag_config_resource_model.go
+++ b/vantage/virtual_tag_config_resource_model.go
@@ -399,19 +399,12 @@ func (m *virtualTagConfigModel) toCreate(ctx context.Context, diags *diag.Diagno
 				value.LabelTransforms = make([]*modelsv2.CreateVirtualTagConfigValuesItems0LabelTransformsItems0, 0, len(data.LabelTransforms))
 				for _, lt := range data.LabelTransforms {
 					ltType := lt.Type
-					item := &modelsv2.CreateVirtualTagConfigValuesItems0LabelTransformsItems0{
-						Type: &ltType,
-					}
-					if lt.Delimiter != nil {
-						item.Delimiter = *lt.Delimiter
-					}
-					if lt.Index != nil {
-						item.Index = *lt.Index
-					}
-					if lt.Template != nil {
-						item.Template = *lt.Template
-					}
-					value.LabelTransforms = append(value.LabelTransforms, item)
+					value.LabelTransforms = append(value.LabelTransforms, &modelsv2.CreateVirtualTagConfigValuesItems0LabelTransformsItems0{
+						Type:      &ltType,
+						Delimiter: lt.Delimiter,
+						Index:     lt.Index,
+						Template:  lt.Template,
+					})
 				}
 			}
 
@@ -518,19 +511,12 @@ func (m *virtualTagConfigModel) toUpdate(ctx context.Context, diags *diag.Diagno
 				value.LabelTransforms = make([]*modelsv2.UpdateVirtualTagConfigValuesItems0LabelTransformsItems0, 0, len(data.LabelTransforms))
 				for _, lt := range data.LabelTransforms {
 					ltType := lt.Type
-					item := &modelsv2.UpdateVirtualTagConfigValuesItems0LabelTransformsItems0{
-						Type: &ltType,
-					}
-					if lt.Delimiter != nil {
-						item.Delimiter = *lt.Delimiter
-					}
-					if lt.Index != nil {
-						item.Index = *lt.Index
-					}
-					if lt.Template != nil {
-						item.Template = *lt.Template
-					}
-					value.LabelTransforms = append(value.LabelTransforms, item)
+					value.LabelTransforms = append(value.LabelTransforms, &modelsv2.UpdateVirtualTagConfigValuesItems0LabelTransformsItems0{
+						Type:      &ltType,
+						Delimiter: lt.Delimiter,
+						Index:     lt.Index,
+						Template:  lt.Template,
+					})
 				}
 			}
 

--- a/vantage/virtual_tag_config_resource_test.go
+++ b/vantage/virtual_tag_config_resource_test.go
@@ -464,6 +464,123 @@ func TestAccVantageVirtualTagConfig_withDateRanges(t *testing.T) {
 	})
 }
 
+func TestAccVantageVirtualTagConfig_withLabelTransforms(t *testing.T) {
+	key := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+	bmTitle := "tf-acc-bm-" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlphaNum)
+	now := time.Now()
+	backfillUntil := now.AddDate(0, -3, -now.Day()+1).Format("2006-01-02")
+	resourceName := "vantage_virtual_tag_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create: value with a split+format label_transforms chain
+			{
+				Config: testAccVantageVirtualTagConfig_withLabelTransformsTf(key, bmTitle, backfillUntil, `
+					label_transforms = [
+						{
+							type      = "split"
+							delimiter = "&&&"
+							index     = 0
+						},
+						{
+							type     = "format"
+							template = "team-{0}"
+						}
+					]
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "values.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "values.0.business_metric_token"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.0.type", "split"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.0.delimiter", "&&&"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.0.index", "0"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.1.type", "format"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.1.template", "team-{0}"),
+				),
+			},
+			// No drift
+			{
+				Config: testAccVantageVirtualTagConfig_withLabelTransformsTf(key, bmTitle, backfillUntil, `
+					label_transforms = [
+						{
+							type      = "split"
+							delimiter = "&&&"
+							index     = 0
+						},
+						{
+							type     = "format"
+							template = "team-{0}"
+						}
+					]
+				`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Update: swap to a single split transform at a different index
+			{
+				Config: testAccVantageVirtualTagConfig_withLabelTransformsTf(key, bmTitle, backfillUntil, `
+					label_transforms = [
+						{
+							type      = "split"
+							delimiter = "|||"
+							index     = 1
+						}
+					]
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.0.type", "split"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.0.delimiter", "|||"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.0.index", "1"),
+				),
+			},
+			// Remove label_transforms
+			{
+				Config: testAccVantageVirtualTagConfig_withLabelTransformsTf(key, bmTitle, backfillUntil, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVantageVirtualTagConfig_withLabelTransformsTf(key, bmTitle, backfillUntil, labelTransformsHCL string) string {
+	return fmt.Sprintf(`
+resource "vantage_business_metric" "test" {
+  title = %[2]q
+  values = [
+    {
+      date   = "2024-01-01"
+      amount = 1.0
+      label  = "team-a&&&proj-1"
+    },
+    {
+      date   = "2024-01-01"
+      amount = 1.0
+      label  = "team-b&&&proj-2"
+    }
+  ]
+}
+
+resource "vantage_virtual_tag_config" "test" {
+  key            = %[1]q
+  overridable    = true
+  backfill_until = %[3]q
+  values = [
+    {
+      filter                = "costs.provider = 'aws'"
+      business_metric_token = vantage_business_metric.test.token
+      %[4]s
+    }
+  ]
+}
+`, key, bmTitle, backfillUntil, labelTransformsHCL)
+}
+
 func testAccVantageVirtualTagConfig_basicTf(id string, key string, overridable bool, backfillUntil string, rest string) string {
 	return fmt.Sprintf(
 		`data "vantage_virtual_tag_configs" %[1]q {}


### PR DESCRIPTION
## Summary

- Exposes `label_transforms` on `vantage_virtual_tag_config` values — a list of `split` / `format` (or chained) transforms applied to business-metric labels before they become the emitted tag value. This is what's required to replicate CloudZero-style `&&&` / `|||` multi-project splits in Terraform (core shipped this in vantage-sh/core#18317 / FIN-3228).
- Regenerates the resource/data-source schemas against prod swagger, which also adds the `filter` attribute on `collapsed_tag_keys` (same `vantage-go` regen); both fields are now wired through `applyPayload`, `toCreate`, `toUpdate`, and `toValueData` so nothing drifts silently.
- Adds `TestAccVantageVirtualTagConfig_withLabelTransforms` (create with split+format chain, PlanOnly no-drift, update to single split at new index, clear) + a commented CloudZero-style example in `examples/resources/vantage_virtual_tag_config/resource.tf` + docs updates.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./vantage/` (unit tests)
- [x] `TF_ACC=1 make test` against a live API to run `TestAccVantageVirtualTagConfig_withLabelTransforms`
