### PR TITLE
Fix managed accounts data source test to create its own managed account

### DIFF
--- a/vantage/managed_accounts_data_source_test.go
+++ b/vantage/managed_accounts_data_source_test.go
@@ -1,14 +1,24 @@
 package vantage
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/vantage-sh/terraform-provider-vantage/vantage/acctest"
 )
 
 func TestAccVantageManagedAccountsDataSource_basic(t *testing.T) {
 	resourceName := "data.vantage_managed_accounts.test"
+
+	domain := os.Getenv("MANAGED_ACCOUNT_DOMAIN")
+	if domain == "" {
+		domain = "vantage.sh"
+	}
+	address := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+	contactEmail := fmt.Sprintf("%s@%s", address, domain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -18,7 +28,7 @@ func TestAccVantageManagedAccountsDataSource_basic(t *testing.T) {
 				// This test verifies the data source doesn't throw a
 				// "Value Conversion Error" due to schema mismatch.
 				// See: https://github.com/vantage-sh/terraform-provider-vantage/issues/154
-				Config: testAccManagedAccountsDataSourceConfig,
+				Config: testAccManagedAccountsDataSourceConfig(contactEmail),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "managed_accounts.#"),
 				),
@@ -27,6 +37,15 @@ func TestAccVantageManagedAccountsDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccManagedAccountsDataSourceConfig = `
-data "vantage_managed_accounts" "test" {}
-`
+func testAccManagedAccountsDataSourceConfig(contactEmail string) string {
+	return fmt.Sprintf(`
+resource "vantage_managed_account" "test" {
+	name          = "Test Account"
+	contact_email = %[1]q
+}
+
+data "vantage_managed_accounts" "test" {
+	depends_on = [vantage_managed_account.test]
+}
+`, contactEmail)
+}


### PR DESCRIPTION
## Summary

- `TestAccVantageManagedAccountsDataSource_basic` previously assumed a managed account already existed in the test environment, causing it to fail on a fresh environment
- The test now creates a `vantage_managed_account` resource as part of its config and uses `depends_on` so the data source query runs after creation

Related to #187.

## Test plan

- [x] `TestAccVantageManagedAccountsDataSource_basic` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to acceptance test setup, creating a managed account fixture to avoid relying on pre-existing state.
> 
> **Overview**
> Updates `TestAccVantageManagedAccountsDataSource_basic` to create its own `vantage_managed_account` fixture with a randomized `contact_email` (optionally using `MANAGED_ACCOUNT_DOMAIN`) before querying the `vantage_managed_accounts` data source.
> 
> Replaces the static test config constant with a parameterized config helper and adds `depends_on` so the data source read runs after the managed account is created, preventing failures in fresh test environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da533fd2ea2ca535b9440446df5dc3d90bb8ff4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->