### PR TITLE
chore: tailor CODEOWNERS for Dependabot (engineering-platform)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Dependabot dependency manifests — @vantage-sh/engineering-platform
+# Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, gomod).
+/.github/workflows/**/* @vantage-sh/engineering-platform
+/go.mod @vantage-sh/engineering-platform
+/go.sum @vantage-sh/engineering-platform


### PR DESCRIPTION
Assign `@vantage-sh/engineering-platform` as CODEOWNERS for Dependabot-related paths only (from `.github/dependabot.yml` plus repo manifest inference).

- **core**: updates `config/teams/engineering_platform.yml` and regenerated `.github/CODEOWNERS` entries for bundler, npm, docker, and docker-compose; GitHub Actions remain under existing `.github/**/*` ownership.
- **Other repos**: `.github/CODEOWNERS` lists only manifests for the ecosystems this repo uses.

Regenerate across the org later with: `node generate-tailored-dependabot-codeowners.mjs` at the ghorg root (repos other than `core`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub CODEOWNERS rules, affecting review routing for workflow and Go module files but not runtime behavior.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` file that assigns `@vantage-sh/engineering-platform` as code owners for Dependabot-relevant dependency manifests (`.github/workflows/**/*`, `go.mod`, `go.sum`), updating who is requested for reviews on changes to these files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a6b269ea87515811e293c3ee6bbedeea7228d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Related to PLA-1407