### PR TITLE
fix: emit known-empty lists for optional vtc nested attributes

### DIFF
--- a/vantage/virtual_tag_config_resource_model.go
+++ b/vantage/virtual_tag_config_resource_model.go
@@ -196,46 +196,24 @@ func buildValueFromPayload(ctx context.Context, v *modelsv2.VirtualTagConfigValu
 		costMetricValue = costMetric
 	}
 
-	// Build percentages value
-	var percentagesValue attr.Value = types.ListNull(resource_virtual_tag_config.PercentagesType{
-		ObjectType: basetypes.ObjectType{
-			AttrTypes: resource_virtual_tag_config.PercentagesValue{}.AttributeTypes(ctx),
-		},
-	})
-	if v.Percentages != nil && len(v.Percentages) > 0 {
-		percentages, d := buildPercentagesFromPayload(ctx, v.Percentages)
-		if d.HasError() {
-			return basetypes.ObjectValue{}, d
-		}
-		percentagesValue = percentages
+	// Always build percentages/date_ranges/label_transforms as known lists (empty
+	// when the API returns no entries). Emitting types.ListNull here would
+	// mismatch a planned known-empty list and trigger "Provider produced
+	// inconsistent result after apply" — these attributes are Optional+Computed
+	// lists, so Terraform treats null and [] as distinct values.
+	percentagesValue, d := buildPercentagesFromPayload(ctx, v.Percentages)
+	if d.HasError() {
+		return basetypes.ObjectValue{}, d
 	}
 
-	// Build date_ranges value
-	var dateRangesValue attr.Value = types.ListNull(resource_virtual_tag_config.DateRangesType{
-		ObjectType: basetypes.ObjectType{
-			AttrTypes: resource_virtual_tag_config.DateRangesValue{}.AttributeTypes(ctx),
-		},
-	})
-	if len(v.DateRanges) > 0 {
-		dateRanges, d := buildDateRangesFromPayload(ctx, v.DateRanges)
-		if d.HasError() {
-			return basetypes.ObjectValue{}, d
-		}
-		dateRangesValue = dateRanges
+	dateRangesValue, d := buildDateRangesFromPayload(ctx, v.DateRanges)
+	if d.HasError() {
+		return basetypes.ObjectValue{}, d
 	}
 
-	// Build label_transforms value
-	var labelTransformsValue attr.Value = types.ListNull(resource_virtual_tag_config.LabelTransformsType{
-		ObjectType: basetypes.ObjectType{
-			AttrTypes: resource_virtual_tag_config.LabelTransformsValue{}.AttributeTypes(ctx),
-		},
-	})
-	if len(v.LabelTransforms) > 0 {
-		labelTransforms, d := buildLabelTransformsFromPayload(ctx, v.LabelTransforms)
-		if d.HasError() {
-			return basetypes.ObjectValue{}, d
-		}
-		labelTransformsValue = labelTransforms
+	labelTransformsValue, d := buildLabelTransformsFromPayload(ctx, v.LabelTransforms)
+	if d.HasError() {
+		return basetypes.ObjectValue{}, d
 	}
 
 	// Use the constructor to properly set the state field
@@ -269,7 +247,14 @@ func (m *virtualTagConfigModel) applyPayload(ctx context.Context, payload *model
 
 	tfCollapsedTagKeys := make([]resource_virtual_tag_config.CollapsedTagKeysValue, 0, len(payload.CollapsedTagKeys))
 	for _, c := range payload.CollapsedTagKeys {
-		tfProviders, diag := types.ListValueFrom(ctx, types.StringType, c.Providers)
+		// Coalesce a nil Providers slice to an empty slice so ListValueFrom emits
+		// a known-empty list instead of null. Schema declares providers as
+		// Optional+Computed; null vs [] would fail post-apply consistency checks.
+		providers := c.Providers
+		if providers == nil {
+			providers = []string{}
+		}
+		tfProviders, diag := types.ListValueFrom(ctx, types.StringType, providers)
 		if diag.HasError() {
 			return diag
 		}

--- a/vantage/virtual_tag_config_resource_model_test.go
+++ b/vantage/virtual_tag_config_resource_model_test.go
@@ -1,0 +1,157 @@
+package vantage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/vantage-sh/terraform-provider-vantage/vantage/resource_virtual_tag_config"
+	modelsv2 "github.com/vantage-sh/vantage-go/vantagev2/models"
+)
+
+// Regression for ENG-2415: applyPayload must emit known-empty lists (not null)
+// for Optional+Computed nested lists when the API response has nil/empty fields.
+// Terraform treats null != [] for list attributes, so a planned known-empty
+// list paired with a null read-back fails the post-apply consistency check.
+func TestVirtualTagConfig_ApplyPayload_NilNestedListsAreKnownEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	name := "value-0"
+	filter := "costs.provider = 'aws'"
+	createdBy := "usr_test"
+
+	payload := &modelsv2.VirtualTagConfig{
+		Token:          "vtag_test",
+		Key:            "test-key",
+		Overridable:    true,
+		BackfillUntil:  "2025-01-01",
+		CreatedByToken: &createdBy,
+		CollapsedTagKeys: []*modelsv2.VirtualTagConfigCollapsedTagKey{
+			{
+				Key:       "environment",
+				Providers: nil,
+			},
+		},
+		Values: []*modelsv2.VirtualTagConfigValue{
+			{
+				Name:            &name,
+				Filter:          &filter,
+				DateRanges:      nil,
+				Percentages:     nil,
+				LabelTransforms: nil,
+			},
+		},
+	}
+
+	m := &virtualTagConfigModel{}
+	if diags := m.applyPayload(ctx, payload); diags.HasError() {
+		t.Fatalf("applyPayload returned errors: %v", diags)
+	}
+
+	if m.CollapsedTagKeys.IsNull() {
+		t.Fatalf("CollapsedTagKeys is null; want known list")
+	}
+	ctkElements := m.CollapsedTagKeys.Elements()
+	if len(ctkElements) != 1 {
+		t.Fatalf("CollapsedTagKeys has %d elements; want 1", len(ctkElements))
+	}
+	ctk, ok := ctkElements[0].(resource_virtual_tag_config.CollapsedTagKeysValue)
+	if !ok {
+		t.Fatalf("CollapsedTagKeys[0] is %T; want CollapsedTagKeysValue", ctkElements[0])
+	}
+	if ctk.Providers.IsNull() {
+		t.Errorf("collapsed_tag_keys[0].providers is null; want known-empty list")
+	}
+	if !ctk.Providers.IsNull() && len(ctk.Providers.Elements()) != 0 {
+		t.Errorf("collapsed_tag_keys[0].providers has %d elements; want 0",
+			len(ctk.Providers.Elements()))
+	}
+
+	if m.Values.IsNull() {
+		t.Fatalf("Values is null; want known list")
+	}
+	valueElements := m.Values.Elements()
+	if len(valueElements) != 1 {
+		t.Fatalf("Values has %d elements; want 1", len(valueElements))
+	}
+	valueObj, ok := valueElements[0].(basetypes.ObjectValue)
+	if !ok {
+		t.Fatalf("Values[0] is %T; want basetypes.ObjectValue", valueElements[0])
+	}
+	attrs := valueObj.Attributes()
+	for _, field := range []string{"date_ranges", "percentages", "label_transforms"} {
+		raw, exists := attrs[field]
+		if !exists {
+			t.Errorf("values[0].%s is missing", field)
+			continue
+		}
+		listVal, ok := raw.(basetypes.ListValue)
+		if !ok {
+			t.Errorf("values[0].%s is %T; want basetypes.ListValue", field, raw)
+			continue
+		}
+		if listVal.IsNull() {
+			t.Errorf("values[0].%s is null; want known-empty list", field)
+			continue
+		}
+		if len(listVal.Elements()) != 0 {
+			t.Errorf("values[0].%s has %d elements; want 0", field, len(listVal.Elements()))
+		}
+	}
+}
+
+// Verifies populated nested lists round-trip through applyPayload unchanged.
+func TestVirtualTagConfig_ApplyPayload_PopulatedNestedLists(t *testing.T) {
+	ctx := context.Background()
+
+	name := "value-0"
+	filter := "costs.provider = 'aws'"
+	createdBy := "usr_test"
+	startDate := "2024-01-01"
+	endDate := "2024-03-31"
+
+	payload := &modelsv2.VirtualTagConfig{
+		Token:          "vtag_test",
+		Key:            "test-key",
+		Overridable:    true,
+		BackfillUntil:  "2025-01-01",
+		CreatedByToken: &createdBy,
+		CollapsedTagKeys: []*modelsv2.VirtualTagConfigCollapsedTagKey{
+			{
+				Key:       "project",
+				Providers: []string{"aws", "gcp"},
+			},
+		},
+		Values: []*modelsv2.VirtualTagConfigValue{
+			{
+				Name:   &name,
+				Filter: &filter,
+				DateRanges: []*modelsv2.VirtualTagConfigValueDateRange{
+					{StartDate: &startDate, EndDate: &endDate},
+				},
+			},
+		},
+	}
+
+	m := &virtualTagConfigModel{}
+	if diags := m.applyPayload(ctx, payload); diags.HasError() {
+		t.Fatalf("applyPayload returned errors: %v", diags)
+	}
+
+	ctk := m.CollapsedTagKeys.Elements()[0].(resource_virtual_tag_config.CollapsedTagKeysValue)
+	if ctk.Providers.IsNull() {
+		t.Fatalf("providers is null; want [\"aws\",\"gcp\"]")
+	}
+	if got := len(ctk.Providers.Elements()); got != 2 {
+		t.Errorf("providers has %d elements; want 2", got)
+	}
+
+	valueObj := m.Values.Elements()[0].(basetypes.ObjectValue)
+	dr := valueObj.Attributes()["date_ranges"].(basetypes.ListValue)
+	if dr.IsNull() {
+		t.Fatalf("date_ranges is null; want 1 element")
+	}
+	if got := len(dr.Elements()); got != 1 {
+		t.Errorf("date_ranges has %d elements; want 1", got)
+	}
+}

--- a/vantage/virtual_tag_config_resource_test.go
+++ b/vantage/virtual_tag_config_resource_test.go
@@ -581,6 +581,75 @@ resource "vantage_virtual_tag_config" "test" {
 `, key, bmTitle, backfillUntil, labelTransformsHCL)
 }
 
+// Regression for ENG-2415. Customer hit "Provider produced inconsistent result
+// after apply" when collapsed_tag_keys[].providers and values[].date_ranges
+// round-tripped as null while the plan held known list values. Exercises the
+// same shape (single-element providers, several values with no nested lists)
+// and asserts an immediate re-plan reports no drift.
+func TestAccVantageVirtualTagConfig_optionalListsConsistent(t *testing.T) {
+	key := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+	now := time.Now()
+	backfillUntil := now.AddDate(0, -3, -now.Day()+1).Format("2006-01-02")
+	resourceName := "vantage_virtual_tag_config.test"
+
+	config := testAccVantageVirtualTagConfig_basicTf("test", key, true, backfillUntil, `
+		collapsed_tag_keys = [
+			{
+				key       = "environment"
+				providers = ["aws"]
+			},
+			{
+				key = "service"
+			}
+		]
+		values = [
+			{
+				name   = "v0"
+				filter = "costs.provider = 'aws'"
+			},
+			{
+				name   = "v1"
+				filter = "costs.provider = 'gcp'"
+			},
+			{
+				name        = "v2"
+				filter      = "costs.provider = 'azure'"
+				date_ranges = []
+			}
+		]`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create — this step also runs the post-apply consistency check
+			// that fired in the customer report. With the old read path,
+			// providers=["aws"] in plan vs null in state would fail here.
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "collapsed_tag_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "collapsed_tag_keys.0.key", "environment"),
+					resource.TestCheckResourceAttr(resourceName, "collapsed_tag_keys.0.providers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "collapsed_tag_keys.0.providers.0", "aws"),
+					resource.TestCheckResourceAttr(resourceName, "collapsed_tag_keys.1.key", "service"),
+					resource.TestCheckResourceAttr(resourceName, "values.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.date_ranges.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.percentages.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label_transforms.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "values.2.date_ranges.#", "0"),
+				),
+			},
+			// No drift on re-plan.
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func testAccVantageVirtualTagConfig_basicTf(id string, key string, overridable bool, backfillUntil string, rest string) string {
 	return fmt.Sprintf(
 		`data "vantage_virtual_tag_configs" %[1]q {}


### PR DESCRIPTION
## Summary

- `buildValueFromPayload` now always calls the `build*FromPayload` helpers for `date_ranges`, `percentages`, and `label_transforms` instead of falling through to `types.ListNull(...)` when the underlying slice is empty. The helpers already return known-empty lists for empty inputs.
- `applyPayload` coalesces a nil `c.Providers` to `[]string{}` before `types.ListValueFrom`, so `collapsed_tag_keys[].providers` lands as a known-empty list rather than null.
- Adds unit coverage in `vantage/virtual_tag_config_resource_model_test.go` for nil and populated nested-list round-trips through `applyPayload`.
- Adds `TestAccVantageVirtualTagConfig_optionalListsConsistent` mirroring the customer's HCL shape (single-element `providers`, several values with no `date_ranges`) and asserting no drift on re-plan.

## Why

`vantage_virtual_tag_config` fails Terraform's post-apply consistency check when the API response omits an optional list. Customer report (Schueco-Test) in ENG-2415 hit two flavors:

```
.values[N].date_ranges: was cty.ListValEmpty(...), but now null
.collapsed_tag_keys[0].providers: was cty.ListVal(["aws"]), but now null
```

Terraform-plugin-framework treats null and `[]` as distinct for list attributes, so a planned known-empty (or known-populated) list paired with a null read-back fails the check. The provider's `applyPayload` was emitting null for nil/empty inputs because `types.ListValueFrom(ctx, T, nil)` produces a null list, not an empty one.

A companion API symmetry fix in core makes the wire format consistent (vantage-sh/core PR forthcoming), but this provider-side normalization is defense-in-depth: state is always known regardless of what the API returns.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./vantage/...` — new unit tests pass; existing tests unaffected
- [x] Acceptance test run by CI (`TF_ACC=1`)
- [ ] Customer (Schueco-Test) confirms `tofu apply` converges on `values[].date_ranges` after provider upgrade. (The `collapsed_tag_keys[0].providers` failure requires a separate one-line HCL edit on their side — covered in the customer comm on ENG-2415.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk state-mapping change that only affects how empty/nil nested list fields are represented (null vs `[]`), plus added regression coverage.
> 
> **Overview**
> Fixes Terraform post-apply "inconsistent result" errors for `vantage_virtual_tag_config` by ensuring Optional+Computed nested list attributes round-trip as **known lists** (empty `[]` when absent) rather than `null`.
> 
> `buildValueFromPayload` now always emits known list values for `values[].percentages`, `values[].date_ranges`, and `values[].label_transforms`, and `applyPayload` coalesces `collapsed_tag_keys[].providers` from `nil` to an empty slice before `ListValueFrom`. Adds targeted unit tests and an acceptance regression test that asserts no drift on immediate re-plan for the reported customer config shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530b4a9bbc10daa6d652c8f008be23c9d5c77e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->