### PR TITLE
fix: keep business metric values known in update plans

### DIFF
--- a/vantage/business_metric_resource.go
+++ b/vantage/business_metric_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/vantage-sh/terraform-provider-vantage/vantage/resource_business_metric"
@@ -52,8 +53,26 @@ func (r *businessMetricResource) Schema(ctx context.Context, req resource.Schema
 			stringplanmodifier.UseStateForUnknown(),
 		},
 	}
+	applyEmptyLabelDefault(s.Attributes, "values")
+	applyEmptyLabelDefault(s.Attributes, "forecasted_values")
 
 	resp.Schema = s
+}
+
+func applyEmptyLabelDefault(attrs map[string]schema.Attribute, attrName string) {
+	attr, ok := attrs[attrName].(schema.ListNestedAttribute)
+	if !ok {
+		return
+	}
+
+	labelAttr, ok := attr.NestedObject.Attributes["label"].(schema.StringAttribute)
+	if !ok {
+		return
+	}
+
+	labelAttr.Default = stringdefault.StaticString("")
+	attr.NestedObject.Attributes["label"] = labelAttr
+	attrs[attrName] = attr
 }
 
 func (r *businessMetricResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/vantage/business_metric_resource_test.go
+++ b/vantage/business_metric_resource_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/vantage-sh/terraform-provider-vantage/vantage/acctest"
 )
 
@@ -311,6 +313,140 @@ func testAccVantageBusinessMetricTf_basic(id string, title string, valuesStr str
 		 }
 		`, id, title, valuesStr,
 	)
+}
+
+func TestAccBusinessMetric_valuesKnownInUpdatePlan(t *testing.T) {
+	now := time.Now()
+	date1 := fmt.Sprintf("%d-01-01", now.Year())
+	date2 := fmt.Sprintf("%d-02-01", now.Year())
+	date3 := fmt.Sprintf("%d-03-01", now.Year())
+	resourceName := "vantage_business_metric.test_values_plan"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVantageBusinessMetricTf_valuesKnownInUpdatePlan(
+					"Business Metric Values Plan Visibility",
+					[]testAccBusinessMetricValue{
+						{date: date1, amount: "100.50"},
+						{date: date2, amount: "200.75"},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "token"),
+					resource.TestCheckResourceAttr(resourceName, "values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "values.0.label", ""),
+					resource.TestCheckResourceAttr(resourceName, "values.1.label", ""),
+				),
+			},
+			{
+				Config: testAccVantageBusinessMetricTf_valuesKnownInUpdatePlan(
+					"Business Metric Values Plan Visibility Updated",
+					[]testAccBusinessMetricValue{
+						{date: date1, amount: "100.50"},
+						{date: date2, amount: "250.25"},
+						{date: date3, amount: "300.00"},
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						expectKnownResourceValue(resourceName, "values.0.date", tfjsonpath.New("values").AtSliceIndex(0).AtMapKey("date")),
+						expectKnownResourceValue(resourceName, "values.0.amount", tfjsonpath.New("values").AtSliceIndex(0).AtMapKey("amount")),
+						expectKnownResourceValue(resourceName, "values.0.label", tfjsonpath.New("values").AtSliceIndex(0).AtMapKey("label")),
+						expectKnownResourceValue(resourceName, "values.1.date", tfjsonpath.New("values").AtSliceIndex(1).AtMapKey("date")),
+						expectKnownResourceValue(resourceName, "values.1.amount", tfjsonpath.New("values").AtSliceIndex(1).AtMapKey("amount")),
+						expectKnownResourceValue(resourceName, "values.1.label", tfjsonpath.New("values").AtSliceIndex(1).AtMapKey("label")),
+						expectKnownResourceValue(resourceName, "values.2.date", tfjsonpath.New("values").AtSliceIndex(2).AtMapKey("date")),
+						expectKnownResourceValue(resourceName, "values.2.amount", tfjsonpath.New("values").AtSliceIndex(2).AtMapKey("amount")),
+						expectKnownResourceValue(resourceName, "values.2.label", tfjsonpath.New("values").AtSliceIndex(2).AtMapKey("label")),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "title", "Business Metric Values Plan Visibility Updated"),
+					resource.TestCheckResourceAttr(resourceName, "values.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "values.1.amount", "250.25"),
+					resource.TestCheckResourceAttr(resourceName, "values.2.date", date3),
+					resource.TestCheckResourceAttr(resourceName, "values.2.label", ""),
+				),
+			},
+		},
+	})
+}
+
+type testAccBusinessMetricValue struct {
+	date   string
+	amount string
+	label  string
+}
+
+func testAccVantageBusinessMetricTf_valuesKnownInUpdatePlan(title string, values []testAccBusinessMetricValue) string {
+	valuesBlock := ""
+	if len(values) > 0 {
+		valueBlocks := make([]string, 0, len(values))
+		for _, value := range values {
+			fields := []string{
+				fmt.Sprintf("date = %[1]q", value.date),
+				fmt.Sprintf("amount = %[1]s", value.amount),
+			}
+			if value.label != "" {
+				fields = append(fields, fmt.Sprintf("label = %[1]q", value.label))
+			}
+			valueBlocks = append(valueBlocks, fmt.Sprintf(`{ %[1]s }`, strings.Join(fields, ", ")))
+		}
+		valuesBlock = fmt.Sprintf(`
+  values = [
+    %[1]s
+  ]
+`, strings.Join(valueBlocks, ",\n    "))
+	}
+
+	return fmt.Sprintf(`
+resource "vantage_business_metric" "test_values_plan" {
+  title = %[1]q
+%[2]s
+}
+`, title, valuesBlock)
+}
+
+type expectKnownResourceValuePlanCheck struct {
+	resourceAddress string
+	attributeName   string
+	attributePath   tfjsonpath.Path
+}
+
+func expectKnownResourceValue(resourceAddress, attributeName string, attributePath tfjsonpath.Path) plancheck.PlanCheck {
+	return expectKnownResourceValuePlanCheck{
+		resourceAddress: resourceAddress,
+		attributeName:   attributeName,
+		attributePath:   attributePath,
+	}
+}
+
+func (e expectKnownResourceValuePlanCheck) CheckPlan(_ context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	for _, resourceChange := range req.Plan.ResourceChanges {
+		if resourceChange.Address != e.resourceAddress {
+			continue
+		}
+		if resourceChange.Change == nil {
+			resp.Error = fmt.Errorf("resource %s has no planned change", e.resourceAddress)
+			return
+		}
+
+		if unknownValue, err := tfjsonpath.Traverse(resourceChange.Change.AfterUnknown, e.attributePath); err == nil {
+			resp.Error = fmt.Errorf("expected %s.%s to be known in the update plan, but it was marked unknown: %#v", e.resourceAddress, e.attributeName, unknownValue)
+			return
+		}
+
+		if _, err := tfjsonpath.Traverse(resourceChange.Change.After, e.attributePath); err != nil {
+			resp.Error = fmt.Errorf("expected %s.%s to be present in the planned values: %w", e.resourceAddress, e.attributeName, err)
+		}
+		return
+	}
+
+	resp.Error = fmt.Errorf("resource %s was not found in the plan", e.resourceAddress)
 }
 
 func TestAccBusinessMetric_cloudwatch(t *testing.T) {


### PR DESCRIPTION
## Linear Ticket Context
ENG-2299 describes two related `vantage_business_metric` Terraform issues around static `values`.

Bug 1: the ticket reports that refresh/read can reorder `values`, causing Terraform to show a diff even when config has not changed. I tried to reproduce this with an acceptance test that created values in a deliberately non-chronological order, ran a refresh, and then verified a no-op follow-up plan. That did not reproduce on the current provider code: `Read` calls `applyPayload`, but `applyPayload` does not populate `values` from the API response, so the existing Terraform state order is preserved.

Bug 2: the ticket reports that `values` appears as `(known after apply)` in update plans, which hides the user's intended new static values. This did reproduce. The unknown values came from the nested `label` field being `Optional + Computed`; when users omit `label`, Terraform marks each nested `label` unknown during planning, which makes the list appear unknown in the plan output.

## Solution
This PR fixes the reproduced Bug 2 by defaulting omitted `values[*].label` and `forecasted_values[*].label` to `""` in the business metric resource schema. That matches the provider's existing post-apply normalization behavior while making Terraform's update plan fully visible before apply.

The PR also adds an acceptance test that creates a business metric with static values, updates those values, and asserts the pre-apply plan contains known `date`, `amount`, and `label` leaves for every value.

## Summary
- Default omitted business metric value labels to an empty string in the resource schema, matching the provider's existing post-apply normalization.
- Add an acceptance test that verifies updated `values` remain visible in Terraform's pre-apply plan instead of becoming `(known after apply)`.

## Test plan
- `VANTAGE_HOST="http://localhost:3000" TF_ACC=1 go test -v -count=1 -run TestAccBusinessMetric_valuesKnownInUpdatePlan ./...`
- `VANTAGE_HOST="http://localhost:3000" TF_ACC=1 go test -v -count=1 -run 'TestAccBusinessMetric_basic|TestAccBusinessMetric_forecastedValues|TestAccBusinessMetric_withValuesAndForecastedValues' ./...`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Terraform schema defaults for nested `values`/`forecasted_values` labels, which can change planned diffs for existing configs that omit `label`. Functional scope is small and covered by a new acceptance test that asserts plan-time visibility.
> 
> **Overview**
> Ensures `vantage_business_metric` update plans don’t degrade `values`/`forecasted_values` fields to *(known after apply)* when `label` is omitted by defaulting nested `label` attributes to `""` in the resource schema.
> 
> Adds a new acceptance test (`TestAccBusinessMetric_valuesKnownInUpdatePlan`) with custom `plancheck` assertions to verify `values[*].{date,amount,label}` remain present and not marked unknown during an update plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b060028fedd2f5912131bd059e8f8c59afddd29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->