### PR TITLE
FIN-4297 Biz Metrics Updates

### DIFF
--- a/docs/resources/business_metric.md
+++ b/docs/resources/business_metric.md
@@ -67,6 +67,8 @@ Required:
 
 Optional:
 
+- `calculation_type` (String) The calculation type applied when this BusinessMetric is used in the CostReport. Defaults to `unit_cost`.
+- `label` (String) Optional custom display name for this BusinessMetric on the CostReport. When omitted, a default is derived from the calculation type.
 - `label_filter` (List of String) Include only values with these labels in the CostReport.
 - `unit_scale` (String) Determines the scale of the BusinessMetric's values within the CostReport.
 

--- a/examples/resources/vantage_business_metrics/cost_report_tokens_example.tf
+++ b/examples/resources/vantage_business_metrics/cost_report_tokens_example.tf
@@ -41,11 +41,14 @@ resource "vantage_business_metric" "fills_trades" {
     {
       cost_report_token = vantage_cost_report.all_resources.token
       unit_scale        = "per_unit"
+      calculation_type  = "unit_cost"
       label_filter      = []
     },
     {
       cost_report_token = vantage_cost_report.domains.token
       unit_scale        = "per_unit"
+      calculation_type  = "gross_margin"
+      label             = "Domain Gross Margin"
       label_filter      = []
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/vantage-sh/vantage-go v0.0.93
+	github.com/vantage-sh/vantage-go v0.0.94
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vantage-sh/vantage-go v0.0.93 h1:Nh0MHO2XmDD4+nRjs8C/izWhmXepcO8eFy/kZPH4KEA=
-github.com/vantage-sh/vantage-go v0.0.93/go.mod h1:+AplFOIL/egitn/MvmQXPS4hQw7Yi61+H3HglnVWwpU=
+github.com/vantage-sh/vantage-go v0.0.94 h1:YZafyCULyZvCijdGXVaH/Afi0UxCyXz/7cFPCwoE9pw=
+github.com/vantage-sh/vantage-go v0.0.94/go.mod h1:+AplFOIL/egitn/MvmQXPS4hQw7Yi61+H3HglnVWwpU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/vantage/business_metric_resource.go
+++ b/vantage/business_metric_resource.go
@@ -55,6 +55,7 @@ func (r *businessMetricResource) Schema(ctx context.Context, req resource.Schema
 	}
 	applyEmptyLabelDefault(s.Attributes, "values")
 	applyEmptyLabelDefault(s.Attributes, "forecasted_values")
+	applyCostReportTokenMetadataDefaults(s.Attributes)
 
 	resp.Schema = s
 }
@@ -73,6 +74,34 @@ func applyEmptyLabelDefault(attrs map[string]schema.Attribute, attrName string) 
 	labelAttr.Default = stringdefault.StaticString("")
 	attr.NestedObject.Attributes["label"] = labelAttr
 	attrs[attrName] = attr
+}
+
+func applyCostReportTokenMetadataDefaults(attrs map[string]schema.Attribute) {
+	attr, ok := attrs["cost_report_tokens_with_metadata"].(schema.ListNestedAttribute)
+	if !ok {
+		return
+	}
+
+	if calcAttr, ok := attr.NestedObject.Attributes["calculation_type"].(schema.StringAttribute); ok {
+		attr.NestedObject.Attributes["calculation_type"] = schema.StringAttribute{
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString("unit_cost"),
+			Description:         calcAttr.Description,
+			MarkdownDescription: calcAttr.MarkdownDescription,
+		}
+	}
+
+	if labelAttr, ok := attr.NestedObject.Attributes["label"].(schema.StringAttribute); ok {
+		attr.NestedObject.Attributes["label"] = schema.StringAttribute{
+			Optional:            true,
+			Computed:            true,
+			Description:         labelAttr.Description,
+			MarkdownDescription: labelAttr.MarkdownDescription,
+		}
+	}
+
+	attrs["cost_report_tokens_with_metadata"] = attr
 }
 
 func (r *businessMetricResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/vantage/business_metric_resource_model.go
+++ b/vantage/business_metric_resource_model.go
@@ -24,6 +24,7 @@ type BusinessMetricPayloadApplier interface {
 	SetIntegrationToken(integrationToken types.String)
 	SetCloudwatchFields(cloudwatchFields resource_business_metric.CloudwatchFieldsValue)
 	SetDatadogMetricFields(datadogMetricFields resource_business_metric.DatadogMetricFieldsValue)
+	SetSnowflakeMetricFields(snowflakeMetricFields resource_business_metric.SnowflakeMetricFieldsValue)
 }
 
 type businessMetricResourceModel resource_business_metric.BusinessMetricModel
@@ -37,7 +38,42 @@ type businessMetricResourceModelValue struct {
 type businessMetricResourceModelCostReportToken struct {
 	CostReportToken types.String `tfsdk:"cost_report_token"`
 	UnitScale       types.String `tfsdk:"unit_scale"`
+	CalculationType types.String `tfsdk:"calculation_type"`
+	Label           types.String `tfsdk:"label"`
 	LabelFilter     types.List   `tfsdk:"label_filter"`
+	LabelFilters    types.Map    `tfsdk:"label_filters"`
+}
+
+func resourceCostReportTokenAttrTypes(ctx context.Context) map[string]attr.Type {
+	return resource_business_metric.CostReportTokensWithMetadataValue{}.AttributeTypes(ctx)
+}
+
+func resourceCostReportTokenListType(ctx context.Context) attr.Type {
+	return resource_business_metric.CostReportTokensWithMetadataValue{}.Type(ctx)
+}
+
+func dataSourceCostReportTokenListType(ctx context.Context) attr.Type {
+	return datasource_business_metrics.CostReportTokensWithMetadataValue{}.Type(ctx)
+}
+
+func emptyLabelFiltersMap() types.Map {
+	return types.MapNull(types.ListType{ElemType: types.StringType})
+}
+
+func emptyDataSourceLabelFilters(ctx context.Context) types.Object {
+	return types.ObjectNull(datasource_business_metrics.LabelFiltersValue{}.AttributeTypes(ctx))
+}
+
+// Deprecated: use resourceCostReportTokenAttrTypes. Kept for unit tests that build plain objects.
+func costReportTokenAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"cost_report_token": types.StringType,
+		"unit_scale":        types.StringType,
+		"calculation_type":  types.StringType,
+		"label":             types.StringType,
+		"label_filter":      types.ListType{ElemType: types.StringType},
+		"label_filters":     types.MapType{ElemType: types.ListType{ElemType: types.StringType}},
+	}
 }
 
 func (m *businessMetricResourceModel) SetTitle(title types.String) {
@@ -74,6 +110,10 @@ func (m *businessMetricResourceModel) SetCloudwatchFields(cloudwatchFields resou
 
 func (m *businessMetricResourceModel) SetDatadogMetricFields(datadogMetricFields resource_business_metric.DatadogMetricFieldsValue) {
 	m.DatadogMetricFields = datadogMetricFields
+}
+
+func (m *businessMetricResourceModel) SetSnowflakeMetricFields(snowflakeMetricFields resource_business_metric.SnowflakeMetricFieldsValue) {
+	m.SnowflakeMetricFields = snowflakeMetricFields
 }
 
 func (m *businessMetricDataSourceValue) SetTitle(title types.String) {
@@ -203,6 +243,28 @@ func (m *businessMetricDataSourceValue) SetDatadogMetricFields(datadogMetricFiel
 	m.DatadogMetricFields = objVal
 }
 
+func (m *businessMetricDataSourceValue) SetSnowflakeMetricFields(snowflakeMetricFields resource_business_metric.SnowflakeMetricFieldsValue) {
+	attrTypes := datasource_business_metrics.SnowflakeMetricFieldsValue{}.AttributeTypes(context.Background())
+
+	if snowflakeMetricFields.IsNull() {
+		m.SnowflakeMetricFields = types.ObjectNull(attrTypes)
+		return
+	}
+
+	sqlQuery := snowflakeMetricFields.SqlQuery
+	if sqlQuery.IsNull() || sqlQuery.IsUnknown() {
+		sqlQuery = types.StringValue("")
+	}
+
+	objVal, _ := types.ObjectValue(
+		attrTypes,
+		map[string]attr.Value{
+			"sql_query": sqlQuery,
+		},
+	)
+	m.SnowflakeMetricFields = objVal
+}
+
 func applyPayload[T BusinessMetricPayloadApplier](ctx context.Context, m T, payload *modelsv2.BusinessMetric) diag.Diagnostics {
 	m.SetTitle(types.StringValue(payload.Title))
 	m.SetToken(types.StringValue(payload.Token))
@@ -211,50 +273,113 @@ func applyPayload[T BusinessMetricPayloadApplier](ctx context.Context, m T, payl
 	m.SetImportType(types.StringPointerValue(payload.ImportType))
 	m.SetIntegrationToken(types.StringPointerValue(payload.IntegrationToken))
 
-	tfCloudwatchFields, diag := cloudwatchFieldsFromApiModel(ctx, payload.CloudwatchFields, payload.IntegrationToken)
-	if diag.HasError() {
-		return diag
+	tfCloudwatchFields, d := cloudwatchFieldsFromApiModel(ctx, payload.CloudwatchFields, payload.IntegrationToken)
+	if d.HasError() {
+		return d
 	}
 	m.SetCloudwatchFields(tfCloudwatchFields)
 
-	tfDatadogMetricFields, diag := datadogMetricFieldsFromApiModel(ctx, payload.DatadogMetricFields, payload.IntegrationToken)
-	if diag.HasError() {
-		return diag
+	tfDatadogMetricFields, d := datadogMetricFieldsFromApiModel(ctx, payload.DatadogMetricFields, payload.IntegrationToken)
+	if d.HasError() {
+		return d
 	}
 	m.SetDatadogMetricFields(tfDatadogMetricFields)
 
+	tfSnowflakeMetricFields, d := snowflakeMetricFieldsFromApiModel(ctx, payload.SnowflakeMetricFields, payload.IntegrationToken)
+	if d.HasError() {
+		return d
+	}
+	m.SetSnowflakeMetricFields(tfSnowflakeMetricFields)
+
 	if payload.CostReportTokensWithMetadata != nil {
-		tfCostReportTokens := []businessMetricResourceModelCostReportToken{}
-		for _, costReportToken := range payload.CostReportTokensWithMetadata {
-			labelFilter, diag := types.ListValueFrom(ctx, types.StringType, costReportToken.LabelFilter)
-			if diag.HasError() {
-				return diag
-			}
-			tfCostReportTokens = append(tfCostReportTokens, businessMetricResourceModelCostReportToken{
-				CostReportToken: types.StringPointerValue(costReportToken.CostReportToken),
-				UnitScale:       types.StringValue(costReportToken.UnitScale),
-				LabelFilter:     labelFilter,
-			})
+		var costReportTokens types.List
+		var tokenDiags diag.Diagnostics
+
+		switch any(m).(type) {
+		case *businessMetricDataSourceValue:
+			costReportTokens, tokenDiags = costReportTokensListForDataSource(ctx, payload.CostReportTokensWithMetadata)
+		default:
+			costReportTokens, tokenDiags = costReportTokensListForResource(ctx, payload.CostReportTokensWithMetadata)
 		}
 
-		costReportTokens, diag := types.ListValueFrom(
-			ctx,
-			types.ObjectType{AttrTypes: map[string]attr.Type{
-				"cost_report_token": types.StringType,
-				"unit_scale":        types.StringType,
-				"label_filter":      types.ListType{ElemType: types.StringType},
-			}},
-			tfCostReportTokens,
-		)
-
-		if diag.HasError() {
-			return diag
+		if tokenDiags.HasError() {
+			return tokenDiags
 		}
 
 		m.SetCostReportTokensWithMetadata(costReportTokens)
 	}
 
 	return nil
+}
+
+func costReportTokensListForResource(ctx context.Context, payloadTokens []*modelsv2.AttachedCostReportForBusinessMetric) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	attrTypes := resourceCostReportTokenAttrTypes(ctx)
+	elements := make([]attr.Value, 0, len(payloadTokens))
+
+	for _, costReportToken := range payloadTokens {
+		labelFilter, d := types.ListValueFrom(ctx, types.StringType, costReportToken.LabelFilter)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(resourceCostReportTokenListType(ctx)), diags
+		}
+
+		tokenValue, d := resource_business_metric.NewCostReportTokensWithMetadataValue(
+			attrTypes,
+			map[string]attr.Value{
+				"cost_report_token": types.StringPointerValue(costReportToken.CostReportToken),
+				"unit_scale":        types.StringValue(costReportToken.UnitScale),
+				"calculation_type":  types.StringValue(costReportToken.CalculationType),
+				"label":             types.StringPointerValue(costReportToken.Label),
+				"label_filter":      labelFilter,
+				"label_filters":     emptyLabelFiltersMap(),
+			},
+		)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(resourceCostReportTokenListType(ctx)), diags
+		}
+		elements = append(elements, tokenValue)
+	}
+
+	list, d := types.ListValue(resourceCostReportTokenListType(ctx), elements)
+	diags.Append(d...)
+	return list, diags
+}
+
+func costReportTokensListForDataSource(ctx context.Context, payloadTokens []*modelsv2.AttachedCostReportForBusinessMetric) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	attrTypes := datasource_business_metrics.CostReportTokensWithMetadataValue{}.AttributeTypes(ctx)
+	elements := make([]attr.Value, 0, len(payloadTokens))
+
+	for _, costReportToken := range payloadTokens {
+		labelFilter, d := types.ListValueFrom(ctx, types.StringType, costReportToken.LabelFilter)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(dataSourceCostReportTokenListType(ctx)), diags
+		}
+
+		tokenValue, d := datasource_business_metrics.NewCostReportTokensWithMetadataValue(
+			attrTypes,
+			map[string]attr.Value{
+				"cost_report_token": types.StringPointerValue(costReportToken.CostReportToken),
+				"unit_scale":        types.StringValue(costReportToken.UnitScale),
+				"calculation_type":  types.StringValue(costReportToken.CalculationType),
+				"label":             types.StringPointerValue(costReportToken.Label),
+				"label_filter":      labelFilter,
+				"label_filters":     emptyDataSourceLabelFilters(ctx),
+			},
+		)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(dataSourceCostReportTokenListType(ctx)), diags
+		}
+		elements = append(elements, tokenValue)
+	}
+
+	list, d := types.ListValue(dataSourceCostReportTokenListType(ctx), elements)
+	diags.Append(d...)
+	return list, diags
 }
 
 func (m *businessMetricDataSourceValue) applyPayload(ctx context.Context, payload *modelsv2.BusinessMetric) diag.Diagnostics {
@@ -360,6 +485,8 @@ func (m *businessMetricResourceModel) toCreate(ctx context.Context, diags *diag.
 			costReportToken := &modelsv2.CreateBusinessMetricCostReportTokensWithMetadataItems0{
 				CostReportToken: v.CostReportToken.ValueStringPointer(),
 				UnitScale:       v.UnitScale.ValueStringPointer(),
+				CalculationType: calculationTypePointer(v.CalculationType),
+				Label:           v.Label.ValueString(),
 				LabelFilter:     tfLabelFilter,
 			}
 			costReportTokens = append(costReportTokens, costReportToken)
@@ -502,6 +629,8 @@ func (m *businessMetricResourceModel) toUpdate(ctx context.Context, diags *diag.
 			costReportToken := &modelsv2.UpdateBusinessMetricCostReportTokensWithMetadataItems0{
 				CostReportToken: v.CostReportToken.ValueStringPointer(),
 				UnitScale:       v.UnitScale.ValueStringPointer(),
+				CalculationType: calculationTypePointer(v.CalculationType),
+				Label:           v.Label.ValueString(),
 				LabelFilter:     tfLabelFilter,
 			}
 			costReportTokens = append(costReportTokens, costReportToken)
@@ -607,11 +736,35 @@ func assignCostReportTokens(ctx context.Context, data *businessMetricResourceMod
 				labelFilter, _ = types.ListValueFrom(ctx, types.StringType, []string{})
 			}
 
+			calculationType := apiToken.CalculationType
+			if (calculationType.IsNull() || calculationType.IsUnknown()) && !planToken.CalculationType.IsNull() && !planToken.CalculationType.IsUnknown() {
+				calculationType = planToken.CalculationType
+			}
+			if calculationType.IsNull() || calculationType.IsUnknown() {
+				calculationType = types.StringValue("unit_cost")
+			}
+
+			label := apiToken.Label
+			if (label.IsNull() || label.IsUnknown()) && !planToken.Label.IsNull() && !planToken.Label.IsUnknown() {
+				label = planToken.Label
+			}
+
+			labelFilters := apiToken.LabelFilters
+			if (labelFilters.IsNull() || labelFilters.IsUnknown()) && !planToken.LabelFilters.IsNull() && !planToken.LabelFilters.IsUnknown() {
+				labelFilters = planToken.LabelFilters
+			}
+			if labelFilters.IsNull() || labelFilters.IsUnknown() {
+				labelFilters = emptyLabelFiltersMap()
+			}
+
 			// Use the plan's cost_report_token but take computed values from API
 			orderedTokens = append(orderedTokens, businessMetricResourceModelCostReportToken{
 				CostReportToken: planToken.CostReportToken,
 				UnitScale:       apiToken.UnitScale,
+				CalculationType: calculationType,
+				Label:           label,
 				LabelFilter:     labelFilter,
+				LabelFilters:    labelFilters,
 			})
 			delete(apiTokenMap, tokenKey)
 		} else {
@@ -630,13 +783,28 @@ func assignCostReportTokens(ctx context.Context, data *businessMetricResourceMod
 		orderedTokens = append(orderedTokens, *apiToken)
 	}
 
-	attrTypes := map[string]attr.Type{
-		"cost_report_token": types.StringType,
-		"unit_scale":        types.StringType,
-		"label_filter":      types.ListType{ElemType: types.StringType},
+	elements := make([]attr.Value, 0, len(orderedTokens))
+	attrTypes := resourceCostReportTokenAttrTypes(ctx)
+	for _, token := range orderedTokens {
+		tokenValue, d := resource_business_metric.NewCostReportTokensWithMetadataValue(
+			attrTypes,
+			map[string]attr.Value{
+				"cost_report_token": token.CostReportToken,
+				"unit_scale":        token.UnitScale,
+				"calculation_type":  token.CalculationType,
+				"label":             token.Label,
+				"label_filter":      token.LabelFilter,
+				"label_filters":     token.LabelFilters,
+			},
+		)
+		if d.HasError() {
+			diags.Append(d...)
+			return
+		}
+		elements = append(elements, tokenValue)
 	}
 
-	newList, d := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: attrTypes}, orderedTokens)
+	newList, d := types.ListValue(resourceCostReportTokenListType(ctx), elements)
 	if d.HasError() {
 		diags.Append(d...)
 		return
@@ -658,6 +826,24 @@ func datadogMetricFieldsFromApiModel(ctx context.Context, apiFields *modelsv2.Da
 		},
 		map[string]attr.Value{
 			"query":             types.StringValue(apiFields.Query),
+			"integration_token": types.StringPointerValue(integrationToken),
+		},
+	)
+	diags.Append(d...)
+
+	return tfValue, diags
+}
+
+func snowflakeMetricFieldsFromApiModel(ctx context.Context, apiFields *modelsv2.SnowflakeMetricFields, integrationToken *string) (resource_business_metric.SnowflakeMetricFieldsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if apiFields == nil {
+		return resource_business_metric.NewSnowflakeMetricFieldsValueNull(), diags
+	}
+
+	tfValue, d := resource_business_metric.NewSnowflakeMetricFieldsValue(
+		resource_business_metric.SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"sql_query":         types.StringValue(apiFields.SQLQuery),
 			"integration_token": types.StringPointerValue(integrationToken),
 		},
 	)
@@ -732,4 +918,12 @@ func cloudwatchFieldsFromApiModel(ctx context.Context, apiFields *modelsv2.Cloud
 	}
 
 	return tfValue, diags
+}
+
+func calculationTypePointer(v types.String) *string {
+	if v.IsNull() || v.IsUnknown() || v.ValueString() == "" {
+		unitCost := "unit_cost"
+		return &unitCost
+	}
+	return v.ValueStringPointer()
 }

--- a/vantage/business_metric_resource_test.go
+++ b/vantage/business_metric_resource_test.go
@@ -21,11 +21,7 @@ import (
 func TestAssignCostReportTokens_OrderPreservation(t *testing.T) {
 	ctx := context.Background()
 
-	attrTypes := map[string]attr.Type{
-		"cost_report_token": types.StringType,
-		"unit_scale":        types.StringType,
-		"label_filter":      types.ListType{ElemType: types.StringType},
-	}
+	attrTypes := costReportTokenAttrTypes()
 
 	// Helper to create a cost report token object
 	createToken := func(token, unitScale string) attr.Value {
@@ -37,7 +33,10 @@ func TestAssignCostReportTokens_OrderPreservation(t *testing.T) {
 		obj, err := types.ObjectValue(attrTypes, map[string]attr.Value{
 			"cost_report_token": types.StringValue(token),
 			"unit_scale":        types.StringValue(unitScale),
+			"calculation_type":  types.StringValue("unit_cost"),
+			"label":             types.StringNull(),
 			"label_filter":      labelFilter,
+			"label_filters":     emptyLabelFiltersMap(),
 		})
 		if err != nil {
 			t.Fatalf("failed to create cost report token object: %v", err)
@@ -115,11 +114,7 @@ func TestAssignCostReportTokens_OrderPreservation(t *testing.T) {
 func TestAssignCostReportTokens_NullLabelFilter(t *testing.T) {
 	ctx := context.Background()
 
-	attrTypes := map[string]attr.Type{
-		"cost_report_token": types.StringType,
-		"unit_scale":        types.StringType,
-		"label_filter":      types.ListType{ElemType: types.StringType},
-	}
+	attrTypes := costReportTokenAttrTypes()
 
 	// Helper to create a cost report token with empty label_filter (plan)
 	createTokenWithEmptyFilter := func(token, unitScale string) attr.Value {
@@ -131,7 +126,10 @@ func TestAssignCostReportTokens_NullLabelFilter(t *testing.T) {
 		obj, diags := types.ObjectValue(attrTypes, map[string]attr.Value{
 			"cost_report_token": types.StringValue(token),
 			"unit_scale":        types.StringValue(unitScale),
+			"calculation_type":  types.StringValue("unit_cost"),
+			"label":             types.StringNull(),
 			"label_filter":      labelFilter,
+			"label_filters":     emptyLabelFiltersMap(),
 		})
 		if diags.HasError() {
 			t.Fatalf("failed to create cost report token object (empty label_filter): %v", diags)
@@ -145,7 +143,10 @@ func TestAssignCostReportTokens_NullLabelFilter(t *testing.T) {
 		obj, diags := types.ObjectValue(attrTypes, map[string]attr.Value{
 			"cost_report_token": types.StringValue(token),
 			"unit_scale":        types.StringValue(unitScale),
+			"calculation_type":  types.StringValue("unit_cost"),
+			"label":             types.StringNull(),
 			"label_filter":      types.ListNull(types.StringType),
+			"label_filters":     emptyLabelFiltersMap(),
 		})
 		if diags.HasError() {
 			t.Fatalf("failed to create cost report token object (null label_filter): %v", diags)
@@ -610,6 +611,9 @@ func TestAccBusinessMetric_costReportTokensOrder(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_business_metric.test-tokens", "cost_report_tokens_with_metadata.0.unit_scale", "per_unit"),
 					resource.TestCheckResourceAttr("vantage_business_metric.test-tokens", "cost_report_tokens_with_metadata.1.unit_scale", "per_thousand"),
 					resource.TestCheckResourceAttr("vantage_business_metric.test-tokens", "cost_report_tokens_with_metadata.2.unit_scale", "per_million"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test-tokens", "cost_report_tokens_with_metadata.0.calculation_type", "unit_cost"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test-tokens", "cost_report_tokens_with_metadata.1.calculation_type", "unit_cost"),
+					resource.TestCheckResourceAttr("vantage_business_metric.test-tokens", "cost_report_tokens_with_metadata.2.calculation_type", "unit_cost"),
 				),
 			},
 			{ // update title but keep same cost report tokens order

--- a/vantage/datasource_business_metrics/business_metrics_data_source_gen.go
+++ b/vantage/datasource_business_metrics/business_metrics_data_source_gen.go
@@ -79,16 +79,37 @@ func BusinessMetricsDataSourceSchema(ctx context.Context) schema.Schema {
 						"cost_report_tokens_with_metadata": schema.ListNestedAttribute{
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
+									"calculation_type": schema.StringAttribute{
+										Computed:            true,
+										Description:         "The calculation type applied when this BusinessMetric is used in the CostReport.",
+										MarkdownDescription: "The calculation type applied when this BusinessMetric is used in the CostReport.",
+									},
 									"cost_report_token": schema.StringAttribute{
 										Computed:            true,
 										Description:         "The token of the CostReport the BusinessMetric is attached to.",
 										MarkdownDescription: "The token of the CostReport the BusinessMetric is attached to.",
+									},
+									"label": schema.StringAttribute{
+										Computed:            true,
+										Description:         "Optional custom display name for this BusinessMetric on the CostReport. When omitted, a default is derived from the calculation type.",
+										MarkdownDescription: "Optional custom display name for this BusinessMetric on the CostReport. When omitted, a default is derived from the calculation type.",
 									},
 									"label_filter": schema.ListAttribute{
 										ElementType:         types.StringType,
 										Computed:            true,
 										Description:         "The labels that the BusinessMetric is filtered by within a particular CostReport.",
 										MarkdownDescription: "The labels that the BusinessMetric is filtered by within a particular CostReport.",
+									},
+									"label_filters": schema.SingleNestedAttribute{
+										Attributes: map[string]schema.Attribute{},
+										CustomType: LabelFiltersType{
+											ObjectType: types.ObjectType{
+												AttrTypes: LabelFiltersValue{}.AttributeTypes(ctx),
+											},
+										},
+										Computed:            true,
+										Description:         "The ClickHouse BusinessMetric label filters applied within a CostReport. Each key is required and values within a key are alternatives.",
+										MarkdownDescription: "The ClickHouse BusinessMetric label filters applied within a CostReport. Each key is required and values within a key are alternatives.",
 									},
 									"unit_scale": schema.StringAttribute{
 										Computed:            true,
@@ -140,6 +161,21 @@ func BusinessMetricsDataSourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "The Integration token used to import the BusinessMetric.",
 							MarkdownDescription: "The Integration token used to import the BusinessMetric.",
+						},
+						"snowflake_metric_fields": schema.SingleNestedAttribute{
+							Attributes: map[string]schema.Attribute{
+								"sql_query": schema.StringAttribute{
+									Computed:            true,
+									Description:         "The SQL query used to import Snowflake metrics.",
+									MarkdownDescription: "The SQL query used to import Snowflake metrics.",
+								},
+							},
+							CustomType: SnowflakeMetricFieldsType{
+								ObjectType: types.ObjectType{
+									AttrTypes: SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+								},
+							},
+							Computed: true,
 						},
 						"title": schema.StringAttribute{
 							Computed:            true,
@@ -319,6 +355,24 @@ func (t BusinessMetricsType) ValueFromObject(ctx context.Context, in basetypes.O
 			fmt.Sprintf(`integration_token expected to be basetypes.StringValue, was: %T`, integrationTokenAttribute))
 	}
 
+	snowflakeMetricFieldsAttribute, ok := attributes["snowflake_metric_fields"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`snowflake_metric_fields is missing from object`)
+
+		return nil, diags
+	}
+
+	snowflakeMetricFieldsVal, ok := snowflakeMetricFieldsAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`snowflake_metric_fields expected to be basetypes.ObjectValue, was: %T`, snowflakeMetricFieldsAttribute))
+	}
+
 	titleAttribute, ok := attributes["title"]
 
 	if !ok {
@@ -367,6 +421,7 @@ func (t BusinessMetricsType) ValueFromObject(ctx context.Context, in basetypes.O
 		Id:                           idVal,
 		ImportType:                   importTypeVal,
 		IntegrationToken:             integrationTokenVal,
+		SnowflakeMetricFields:        snowflakeMetricFieldsVal,
 		Title:                        titleVal,
 		Token:                        tokenVal,
 		state:                        attr.ValueStateKnown,
@@ -562,6 +617,24 @@ func NewBusinessMetricsValue(attributeTypes map[string]attr.Type, attributes map
 			fmt.Sprintf(`integration_token expected to be basetypes.StringValue, was: %T`, integrationTokenAttribute))
 	}
 
+	snowflakeMetricFieldsAttribute, ok := attributes["snowflake_metric_fields"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`snowflake_metric_fields is missing from object`)
+
+		return NewBusinessMetricsValueUnknown(), diags
+	}
+
+	snowflakeMetricFieldsVal, ok := snowflakeMetricFieldsAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`snowflake_metric_fields expected to be basetypes.ObjectValue, was: %T`, snowflakeMetricFieldsAttribute))
+	}
+
 	titleAttribute, ok := attributes["title"]
 
 	if !ok {
@@ -610,6 +683,7 @@ func NewBusinessMetricsValue(attributeTypes map[string]attr.Type, attributes map
 		Id:                           idVal,
 		ImportType:                   importTypeVal,
 		IntegrationToken:             integrationTokenVal,
+		SnowflakeMetricFields:        snowflakeMetricFieldsVal,
 		Title:                        titleVal,
 		Token:                        tokenVal,
 		state:                        attr.ValueStateKnown,
@@ -691,13 +765,14 @@ type BusinessMetricsValue struct {
 	Id                           basetypes.StringValue `tfsdk:"id"`
 	ImportType                   basetypes.StringValue `tfsdk:"import_type"`
 	IntegrationToken             basetypes.StringValue `tfsdk:"integration_token"`
+	SnowflakeMetricFields        basetypes.ObjectValue `tfsdk:"snowflake_metric_fields"`
 	Title                        basetypes.StringValue `tfsdk:"title"`
 	Token                        basetypes.StringValue `tfsdk:"token"`
 	state                        attr.ValueState
 }
 
 func (v BusinessMetricsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 9)
+	attrTypes := make(map[string]tftypes.Type, 10)
 
 	var val tftypes.Value
 	var err error
@@ -715,6 +790,9 @@ func (v BusinessMetricsValue) ToTerraformValue(ctx context.Context) (tftypes.Val
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["import_type"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["integration_token"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["snowflake_metric_fields"] = basetypes.ObjectType{
+		AttrTypes: SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
 	attrTypes["title"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["token"] = basetypes.StringType{}.TerraformType(ctx)
 
@@ -722,7 +800,7 @@ func (v BusinessMetricsValue) ToTerraformValue(ctx context.Context) (tftypes.Val
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 9)
+		vals := make(map[string]tftypes.Value, 10)
 
 		val, err = v.CloudwatchFields.ToTerraformValue(ctx)
 
@@ -779,6 +857,14 @@ func (v BusinessMetricsValue) ToTerraformValue(ctx context.Context) (tftypes.Val
 		}
 
 		vals["integration_token"] = val
+
+		val, err = v.SnowflakeMetricFields.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["snowflake_metric_fields"] = val
 
 		val, err = v.Title.ToTerraformValue(ctx)
 
@@ -896,6 +982,27 @@ func (v BusinessMetricsValue) ToObjectValue(ctx context.Context) (basetypes.Obje
 		)
 	}
 
+	var snowflakeMetricFields basetypes.ObjectValue
+
+	if v.SnowflakeMetricFields.IsNull() {
+		snowflakeMetricFields = types.ObjectNull(
+			SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.SnowflakeMetricFields.IsUnknown() {
+		snowflakeMetricFields = types.ObjectUnknown(
+			SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.SnowflakeMetricFields.IsNull() && !v.SnowflakeMetricFields.IsUnknown() {
+		snowflakeMetricFields = types.ObjectValueMust(
+			SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+			v.SnowflakeMetricFields.Attributes(),
+		)
+	}
+
 	attributeTypes := map[string]attr.Type{
 		"cloudwatch_fields": basetypes.ObjectType{
 			AttrTypes: CloudwatchFieldsValue{}.AttributeTypes(ctx),
@@ -910,8 +1017,11 @@ func (v BusinessMetricsValue) ToObjectValue(ctx context.Context) (basetypes.Obje
 		"id":                basetypes.StringType{},
 		"import_type":       basetypes.StringType{},
 		"integration_token": basetypes.StringType{},
-		"title":             basetypes.StringType{},
-		"token":             basetypes.StringType{},
+		"snowflake_metric_fields": basetypes.ObjectType{
+			AttrTypes: SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+		},
+		"title": basetypes.StringType{},
+		"token": basetypes.StringType{},
 	}
 
 	if v.IsNull() {
@@ -932,6 +1042,7 @@ func (v BusinessMetricsValue) ToObjectValue(ctx context.Context) (basetypes.Obje
 			"id":                               v.Id,
 			"import_type":                      v.ImportType,
 			"integration_token":                v.IntegrationToken,
+			"snowflake_metric_fields":          snowflakeMetricFields,
 			"title":                            v.Title,
 			"token":                            v.Token,
 		})
@@ -982,6 +1093,10 @@ func (v BusinessMetricsValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.SnowflakeMetricFields.Equal(other.SnowflakeMetricFields) {
+		return false
+	}
+
 	if !v.Title.Equal(other.Title) {
 		return false
 	}
@@ -1016,8 +1131,11 @@ func (v BusinessMetricsValue) AttributeTypes(ctx context.Context) map[string]att
 		"id":                basetypes.StringType{},
 		"import_type":       basetypes.StringType{},
 		"integration_token": basetypes.StringType{},
-		"title":             basetypes.StringType{},
-		"token":             basetypes.StringType{},
+		"snowflake_metric_fields": basetypes.ObjectType{
+			AttrTypes: SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+		},
+		"title": basetypes.StringType{},
+		"token": basetypes.StringType{},
 	}
 }
 
@@ -2059,6 +2177,24 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 
 	attributes := in.Attributes()
 
+	calculationTypeAttribute, ok := attributes["calculation_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`calculation_type is missing from object`)
+
+		return nil, diags
+	}
+
+	calculationTypeVal, ok := calculationTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`calculation_type expected to be basetypes.StringValue, was: %T`, calculationTypeAttribute))
+	}
+
 	costReportTokenAttribute, ok := attributes["cost_report_token"]
 
 	if !ok {
@@ -2077,6 +2213,24 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 			fmt.Sprintf(`cost_report_token expected to be basetypes.StringValue, was: %T`, costReportTokenAttribute))
 	}
 
+	labelAttribute, ok := attributes["label"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label is missing from object`)
+
+		return nil, diags
+	}
+
+	labelVal, ok := labelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label expected to be basetypes.StringValue, was: %T`, labelAttribute))
+	}
+
 	labelFilterAttribute, ok := attributes["label_filter"]
 
 	if !ok {
@@ -2093,6 +2247,24 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 		diags.AddError(
 			"Attribute Wrong Type",
 			fmt.Sprintf(`label_filter expected to be basetypes.ListValue, was: %T`, labelFilterAttribute))
+	}
+
+	labelFiltersAttribute, ok := attributes["label_filters"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_filters is missing from object`)
+
+		return nil, diags
+	}
+
+	labelFiltersVal, ok := labelFiltersAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_filters expected to be basetypes.ObjectValue, was: %T`, labelFiltersAttribute))
 	}
 
 	unitScaleAttribute, ok := attributes["unit_scale"]
@@ -2118,8 +2290,11 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 	}
 
 	return CostReportTokensWithMetadataValue{
+		CalculationType: calculationTypeVal,
 		CostReportToken: costReportTokenVal,
+		Label:           labelVal,
 		LabelFilter:     labelFilterVal,
+		LabelFilters:    labelFiltersVal,
 		UnitScale:       unitScaleVal,
 		state:           attr.ValueStateKnown,
 	}, diags
@@ -2188,6 +2363,24 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 		return NewCostReportTokensWithMetadataValueUnknown(), diags
 	}
 
+	calculationTypeAttribute, ok := attributes["calculation_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`calculation_type is missing from object`)
+
+		return NewCostReportTokensWithMetadataValueUnknown(), diags
+	}
+
+	calculationTypeVal, ok := calculationTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`calculation_type expected to be basetypes.StringValue, was: %T`, calculationTypeAttribute))
+	}
+
 	costReportTokenAttribute, ok := attributes["cost_report_token"]
 
 	if !ok {
@@ -2206,6 +2399,24 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 			fmt.Sprintf(`cost_report_token expected to be basetypes.StringValue, was: %T`, costReportTokenAttribute))
 	}
 
+	labelAttribute, ok := attributes["label"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label is missing from object`)
+
+		return NewCostReportTokensWithMetadataValueUnknown(), diags
+	}
+
+	labelVal, ok := labelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label expected to be basetypes.StringValue, was: %T`, labelAttribute))
+	}
+
 	labelFilterAttribute, ok := attributes["label_filter"]
 
 	if !ok {
@@ -2222,6 +2433,24 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 		diags.AddError(
 			"Attribute Wrong Type",
 			fmt.Sprintf(`label_filter expected to be basetypes.ListValue, was: %T`, labelFilterAttribute))
+	}
+
+	labelFiltersAttribute, ok := attributes["label_filters"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_filters is missing from object`)
+
+		return NewCostReportTokensWithMetadataValueUnknown(), diags
+	}
+
+	labelFiltersVal, ok := labelFiltersAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_filters expected to be basetypes.ObjectValue, was: %T`, labelFiltersAttribute))
 	}
 
 	unitScaleAttribute, ok := attributes["unit_scale"]
@@ -2247,8 +2476,11 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 	}
 
 	return CostReportTokensWithMetadataValue{
+		CalculationType: calculationTypeVal,
 		CostReportToken: costReportTokenVal,
+		Label:           labelVal,
 		LabelFilter:     labelFilterVal,
+		LabelFilters:    labelFiltersVal,
 		UnitScale:       unitScaleVal,
 		state:           attr.ValueStateKnown,
 	}, diags
@@ -2322,21 +2554,29 @@ func (t CostReportTokensWithMetadataType) ValueType(ctx context.Context) attr.Va
 var _ basetypes.ObjectValuable = CostReportTokensWithMetadataValue{}
 
 type CostReportTokensWithMetadataValue struct {
+	CalculationType basetypes.StringValue `tfsdk:"calculation_type"`
 	CostReportToken basetypes.StringValue `tfsdk:"cost_report_token"`
+	Label           basetypes.StringValue `tfsdk:"label"`
 	LabelFilter     basetypes.ListValue   `tfsdk:"label_filter"`
+	LabelFilters    basetypes.ObjectValue `tfsdk:"label_filters"`
 	UnitScale       basetypes.StringValue `tfsdk:"unit_scale"`
 	state           attr.ValueState
 }
 
 func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 3)
+	attrTypes := make(map[string]tftypes.Type, 6)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["calculation_type"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["cost_report_token"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["label"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["label_filter"] = basetypes.ListType{
 		ElemType: types.StringType,
+	}.TerraformType(ctx)
+	attrTypes["label_filters"] = basetypes.ObjectType{
+		AttrTypes: LabelFiltersValue{}.AttributeTypes(ctx),
 	}.TerraformType(ctx)
 	attrTypes["unit_scale"] = basetypes.StringType{}.TerraformType(ctx)
 
@@ -2344,7 +2584,15 @@ func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context)
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 3)
+		vals := make(map[string]tftypes.Value, 6)
+
+		val, err = v.CalculationType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["calculation_type"] = val
 
 		val, err = v.CostReportToken.ToTerraformValue(ctx)
 
@@ -2354,6 +2602,14 @@ func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context)
 
 		vals["cost_report_token"] = val
 
+		val, err = v.Label.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["label"] = val
+
 		val, err = v.LabelFilter.ToTerraformValue(ctx)
 
 		if err != nil {
@@ -2361,6 +2617,14 @@ func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context)
 		}
 
 		vals["label_filter"] = val
+
+		val, err = v.LabelFilters.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["label_filters"] = val
 
 		val, err = v.UnitScale.ToTerraformValue(ctx)
 
@@ -2399,6 +2663,27 @@ func (v CostReportTokensWithMetadataValue) String() string {
 func (v CostReportTokensWithMetadataValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	var labelFilters basetypes.ObjectValue
+
+	if v.LabelFilters.IsNull() {
+		labelFilters = types.ObjectNull(
+			LabelFiltersValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.LabelFilters.IsUnknown() {
+		labelFilters = types.ObjectUnknown(
+			LabelFiltersValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.LabelFilters.IsNull() && !v.LabelFilters.IsUnknown() {
+		labelFilters = types.ObjectValueMust(
+			LabelFiltersValue{}.AttributeTypes(ctx),
+			v.LabelFilters.Attributes(),
+		)
+	}
+
 	var labelFilterVal basetypes.ListValue
 	switch {
 	case v.LabelFilter.IsUnknown():
@@ -2413,18 +2698,28 @@ func (v CostReportTokensWithMetadataValue) ToObjectValue(ctx context.Context) (b
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
+			"calculation_type":  basetypes.StringType{},
 			"cost_report_token": basetypes.StringType{},
+			"label":             basetypes.StringType{},
 			"label_filter": basetypes.ListType{
 				ElemType: types.StringType,
+			},
+			"label_filters": basetypes.ObjectType{
+				AttrTypes: LabelFiltersValue{}.AttributeTypes(ctx),
 			},
 			"unit_scale": basetypes.StringType{},
 		}), diags
 	}
 
 	attributeTypes := map[string]attr.Type{
+		"calculation_type":  basetypes.StringType{},
 		"cost_report_token": basetypes.StringType{},
+		"label":             basetypes.StringType{},
 		"label_filter": basetypes.ListType{
 			ElemType: types.StringType,
+		},
+		"label_filters": basetypes.ObjectType{
+			AttrTypes: LabelFiltersValue{}.AttributeTypes(ctx),
 		},
 		"unit_scale": basetypes.StringType{},
 	}
@@ -2440,8 +2735,11 @@ func (v CostReportTokensWithMetadataValue) ToObjectValue(ctx context.Context) (b
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
+			"calculation_type":  v.CalculationType,
 			"cost_report_token": v.CostReportToken,
+			"label":             v.Label,
 			"label_filter":      labelFilterVal,
+			"label_filters":     labelFilters,
 			"unit_scale":        v.UnitScale,
 		})
 
@@ -2463,11 +2761,23 @@ func (v CostReportTokensWithMetadataValue) Equal(o attr.Value) bool {
 		return true
 	}
 
+	if !v.CalculationType.Equal(other.CalculationType) {
+		return false
+	}
+
 	if !v.CostReportToken.Equal(other.CostReportToken) {
 		return false
 	}
 
+	if !v.Label.Equal(other.Label) {
+		return false
+	}
+
 	if !v.LabelFilter.Equal(other.LabelFilter) {
+		return false
+	}
+
+	if !v.LabelFilters.Equal(other.LabelFilters) {
 		return false
 	}
 
@@ -2488,12 +2798,277 @@ func (v CostReportTokensWithMetadataValue) Type(ctx context.Context) attr.Type {
 
 func (v CostReportTokensWithMetadataValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
+		"calculation_type":  basetypes.StringType{},
 		"cost_report_token": basetypes.StringType{},
+		"label":             basetypes.StringType{},
 		"label_filter": basetypes.ListType{
 			ElemType: types.StringType,
 		},
+		"label_filters": basetypes.ObjectType{
+			AttrTypes: LabelFiltersValue{}.AttributeTypes(ctx),
+		},
 		"unit_scale": basetypes.StringType{},
 	}
+}
+
+var _ basetypes.ObjectTypable = LabelFiltersType{}
+
+type LabelFiltersType struct {
+	basetypes.ObjectType
+}
+
+func (t LabelFiltersType) Equal(o attr.Type) bool {
+	other, ok := o.(LabelFiltersType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t LabelFiltersType) String() string {
+	return "LabelFiltersType"
+}
+
+func (t LabelFiltersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return LabelFiltersValue{
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelFiltersValueNull() LabelFiltersValue {
+	return LabelFiltersValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewLabelFiltersValueUnknown() LabelFiltersValue {
+	return LabelFiltersValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewLabelFiltersValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (LabelFiltersValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing LabelFiltersValue Attribute Value",
+				"While creating a LabelFiltersValue value, a missing attribute value was detected. "+
+					"A LabelFiltersValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelFiltersValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid LabelFiltersValue Attribute Type",
+				"While creating a LabelFiltersValue value, an invalid attribute value was detected. "+
+					"A LabelFiltersValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelFiltersValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("LabelFiltersValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra LabelFiltersValue Attribute Value",
+				"While creating a LabelFiltersValue value, an extra attribute value was detected. "+
+					"A LabelFiltersValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra LabelFiltersValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewLabelFiltersValueUnknown(), diags
+	}
+
+	if diags.HasError() {
+		return NewLabelFiltersValueUnknown(), diags
+	}
+
+	return LabelFiltersValue{
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelFiltersValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) LabelFiltersValue {
+	object, diags := NewLabelFiltersValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewLabelFiltersValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t LabelFiltersType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewLabelFiltersValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewLabelFiltersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewLabelFiltersValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewLabelFiltersValueMust(LabelFiltersValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t LabelFiltersType) ValueType(ctx context.Context) attr.Value {
+	return LabelFiltersValue{}
+}
+
+var _ basetypes.ObjectValuable = LabelFiltersValue{}
+
+type LabelFiltersValue struct {
+	state attr.ValueState
+}
+
+func (v LabelFiltersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 0)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 0)
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v LabelFiltersValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v LabelFiltersValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v LabelFiltersValue) String() string {
+	return "LabelFiltersValue"
+}
+
+func (v LabelFiltersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{})
+
+	return objVal, diags
+}
+
+func (v LabelFiltersValue) Equal(o attr.Value) bool {
+	other, ok := o.(LabelFiltersValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	return true
+}
+
+func (v LabelFiltersValue) Type(ctx context.Context) attr.Type {
+	return LabelFiltersType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v LabelFiltersValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{}
 }
 
 var _ basetypes.ObjectTypable = DatadogMetricFieldsType{}
@@ -2817,5 +3392,329 @@ func (v DatadogMetricFieldsValue) Type(ctx context.Context) attr.Type {
 func (v DatadogMetricFieldsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
 		"query": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = SnowflakeMetricFieldsType{}
+
+type SnowflakeMetricFieldsType struct {
+	basetypes.ObjectType
+}
+
+func (t SnowflakeMetricFieldsType) Equal(o attr.Type) bool {
+	other, ok := o.(SnowflakeMetricFieldsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t SnowflakeMetricFieldsType) String() string {
+	return "SnowflakeMetricFieldsType"
+}
+
+func (t SnowflakeMetricFieldsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	sqlQueryAttribute, ok := attributes["sql_query"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`sql_query is missing from object`)
+
+		return nil, diags
+	}
+
+	sqlQueryVal, ok := sqlQueryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`sql_query expected to be basetypes.StringValue, was: %T`, sqlQueryAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return SnowflakeMetricFieldsValue{
+		SqlQuery: sqlQueryVal,
+		state:    attr.ValueStateKnown,
+	}, diags
+}
+
+func NewSnowflakeMetricFieldsValueNull() SnowflakeMetricFieldsValue {
+	return SnowflakeMetricFieldsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewSnowflakeMetricFieldsValueUnknown() SnowflakeMetricFieldsValue {
+	return SnowflakeMetricFieldsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewSnowflakeMetricFieldsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (SnowflakeMetricFieldsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing SnowflakeMetricFieldsValue Attribute Value",
+				"While creating a SnowflakeMetricFieldsValue value, a missing attribute value was detected. "+
+					"A SnowflakeMetricFieldsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("SnowflakeMetricFieldsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid SnowflakeMetricFieldsValue Attribute Type",
+				"While creating a SnowflakeMetricFieldsValue value, an invalid attribute value was detected. "+
+					"A SnowflakeMetricFieldsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("SnowflakeMetricFieldsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("SnowflakeMetricFieldsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra SnowflakeMetricFieldsValue Attribute Value",
+				"While creating a SnowflakeMetricFieldsValue value, an extra attribute value was detected. "+
+					"A SnowflakeMetricFieldsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra SnowflakeMetricFieldsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewSnowflakeMetricFieldsValueUnknown(), diags
+	}
+
+	sqlQueryAttribute, ok := attributes["sql_query"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`sql_query is missing from object`)
+
+		return NewSnowflakeMetricFieldsValueUnknown(), diags
+	}
+
+	sqlQueryVal, ok := sqlQueryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`sql_query expected to be basetypes.StringValue, was: %T`, sqlQueryAttribute))
+	}
+
+	if diags.HasError() {
+		return NewSnowflakeMetricFieldsValueUnknown(), diags
+	}
+
+	return SnowflakeMetricFieldsValue{
+		SqlQuery: sqlQueryVal,
+		state:    attr.ValueStateKnown,
+	}, diags
+}
+
+func NewSnowflakeMetricFieldsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) SnowflakeMetricFieldsValue {
+	object, diags := NewSnowflakeMetricFieldsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewSnowflakeMetricFieldsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t SnowflakeMetricFieldsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewSnowflakeMetricFieldsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewSnowflakeMetricFieldsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewSnowflakeMetricFieldsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewSnowflakeMetricFieldsValueMust(SnowflakeMetricFieldsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t SnowflakeMetricFieldsType) ValueType(ctx context.Context) attr.Value {
+	return SnowflakeMetricFieldsValue{}
+}
+
+var _ basetypes.ObjectValuable = SnowflakeMetricFieldsValue{}
+
+type SnowflakeMetricFieldsValue struct {
+	SqlQuery basetypes.StringValue `tfsdk:"sql_query"`
+	state    attr.ValueState
+}
+
+func (v SnowflakeMetricFieldsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["sql_query"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.SqlQuery.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["sql_query"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v SnowflakeMetricFieldsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v SnowflakeMetricFieldsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v SnowflakeMetricFieldsValue) String() string {
+	return "SnowflakeMetricFieldsValue"
+}
+
+func (v SnowflakeMetricFieldsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"sql_query": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"sql_query": v.SqlQuery,
+		})
+
+	return objVal, diags
+}
+
+func (v SnowflakeMetricFieldsValue) Equal(o attr.Value) bool {
+	other, ok := o.(SnowflakeMetricFieldsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.SqlQuery.Equal(other.SqlQuery) {
+		return false
+	}
+
+	return true
+}
+
+func (v SnowflakeMetricFieldsValue) Type(ctx context.Context) attr.Type {
+	return SnowflakeMetricFieldsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v SnowflakeMetricFieldsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"sql_query": basetypes.StringType{},
 	}
 }

--- a/vantage/datasource_kubernetes_efficiency_reports/kubernetes_efficiency_reports_data_source_gen.go
+++ b/vantage/datasource_kubernetes_efficiency_reports/kubernetes_efficiency_reports_data_source_gen.go
@@ -58,8 +58,8 @@ func KubernetesEfficiencyReportsDataSourceSchema(ctx context.Context) schema.Sch
 						},
 						"groupings": schema.StringAttribute{
 							Computed:            true,
-							Description:         "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, labeled, category, pod, label, label:<label_name>.",
-							MarkdownDescription: "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, labeled, category, pod, label, label:<label_name>.",
+							Description:         "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, region, labeled, category, pod, label, label:<label_name>.",
+							MarkdownDescription: "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, region, labeled, category, pod, label, label:<label_name>.",
 						},
 						"id": schema.StringAttribute{
 							Computed:            true,

--- a/vantage/datasource_managed_accounts/managed_accounts_data_source_gen.go
+++ b/vantage/datasource_managed_accounts/managed_accounts_data_source_gen.go
@@ -84,8 +84,8 @@ func ManagedAccountsDataSourceSchema(ctx context.Context) schema.Schema {
 						"billing_rule_tokens": schema.ListAttribute{
 							ElementType:         types.StringType,
 							Computed:            true,
-							Description:         "The tokens for the Billing Rules assigned to the Managed Account.",
-							MarkdownDescription: "The tokens for the Billing Rules assigned to the Managed Account.",
+							Description:         "The tokens for the Billing Rules assigned to the Managed Account, in the order they will execute against this account's cost data.",
+							MarkdownDescription: "The tokens for the Billing Rules assigned to the Managed Account, in the order they will execute against this account's cost data.",
 						},
 						"business_information_attributes": schema.SingleNestedAttribute{
 							Attributes: map[string]schema.Attribute{

--- a/vantage/datasource_recommendation_views/recommendation_views_data_source_gen.go
+++ b/vantage/datasource_recommendation_views/recommendation_views_data_source_gen.go
@@ -53,6 +53,11 @@ func RecommendationViewsDataSourceSchema(ctx context.Context) schema.Schema {
 							Description:         "The id of the resource",
 							MarkdownDescription: "The id of the resource",
 						},
+						"min_savings": schema.Float64Attribute{
+							Computed:            true,
+							Description:         "Filter recommendations with at least this amount of potential savings.",
+							MarkdownDescription: "Filter recommendations with at least this amount of potential savings.",
+						},
 						"provider_ids": schema.ListAttribute{
 							ElementType:         types.StringType,
 							Computed:            true,
@@ -87,6 +92,12 @@ func RecommendationViewsDataSourceSchema(ctx context.Context) schema.Schema {
 						},
 						"token": schema.StringAttribute{
 							Computed: true,
+						},
+						"types": schema.ListAttribute{
+							ElementType:         types.StringType,
+							Computed:            true,
+							Description:         "Filter by one or more recommendation type slugs.",
+							MarkdownDescription: "Filter by one or more recommendation type slugs.",
 						},
 						"workspace_token": schema.StringAttribute{
 							Computed:            true,
@@ -243,6 +254,24 @@ func (t RecommendationViewsType) ValueFromObject(ctx context.Context, in basetyp
 			fmt.Sprintf(`id expected to be basetypes.StringValue, was: %T`, idAttribute))
 	}
 
+	minSavingsAttribute, ok := attributes["min_savings"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`min_savings is missing from object`)
+
+		return nil, diags
+	}
+
+	minSavingsVal, ok := minSavingsAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`min_savings expected to be basetypes.Float64Value, was: %T`, minSavingsAttribute))
+	}
+
 	providerIdsAttribute, ok := attributes["provider_ids"]
 
 	if !ok {
@@ -369,6 +398,24 @@ func (t RecommendationViewsType) ValueFromObject(ctx context.Context, in basetyp
 			fmt.Sprintf(`token expected to be basetypes.StringValue, was: %T`, tokenAttribute))
 	}
 
+	typesAttribute, ok := attributes["types"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`types is missing from object`)
+
+		return nil, diags
+	}
+
+	typesVal, ok := typesAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`types expected to be basetypes.ListValue, was: %T`, typesAttribute))
+	}
+
 	workspaceTokenAttribute, ok := attributes["workspace_token"]
 
 	if !ok {
@@ -398,6 +445,7 @@ func (t RecommendationViewsType) ValueFromObject(ctx context.Context, in basetyp
 		CreatedBy:         createdByVal,
 		EndDate:           endDateVal,
 		Id:                idVal,
+		MinSavings:        minSavingsVal,
 		ProviderIds:       providerIdsVal,
 		Regions:           regionsVal,
 		StartDate:         startDateVal,
@@ -405,6 +453,7 @@ func (t RecommendationViewsType) ValueFromObject(ctx context.Context, in basetyp
 		TagValue:          tagValueVal,
 		Title:             titleVal,
 		Token:             tokenVal,
+		Types:             typesVal,
 		WorkspaceToken:    workspaceTokenVal,
 		state:             attr.ValueStateKnown,
 	}, diags
@@ -581,6 +630,24 @@ func NewRecommendationViewsValue(attributeTypes map[string]attr.Type, attributes
 			fmt.Sprintf(`id expected to be basetypes.StringValue, was: %T`, idAttribute))
 	}
 
+	minSavingsAttribute, ok := attributes["min_savings"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`min_savings is missing from object`)
+
+		return NewRecommendationViewsValueUnknown(), diags
+	}
+
+	minSavingsVal, ok := minSavingsAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`min_savings expected to be basetypes.Float64Value, was: %T`, minSavingsAttribute))
+	}
+
 	providerIdsAttribute, ok := attributes["provider_ids"]
 
 	if !ok {
@@ -707,6 +774,24 @@ func NewRecommendationViewsValue(attributeTypes map[string]attr.Type, attributes
 			fmt.Sprintf(`token expected to be basetypes.StringValue, was: %T`, tokenAttribute))
 	}
 
+	typesAttribute, ok := attributes["types"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`types is missing from object`)
+
+		return NewRecommendationViewsValueUnknown(), diags
+	}
+
+	typesVal, ok := typesAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`types expected to be basetypes.ListValue, was: %T`, typesAttribute))
+	}
+
 	workspaceTokenAttribute, ok := attributes["workspace_token"]
 
 	if !ok {
@@ -736,6 +821,7 @@ func NewRecommendationViewsValue(attributeTypes map[string]attr.Type, attributes
 		CreatedBy:         createdByVal,
 		EndDate:           endDateVal,
 		Id:                idVal,
+		MinSavings:        minSavingsVal,
 		ProviderIds:       providerIdsVal,
 		Regions:           regionsVal,
 		StartDate:         startDateVal,
@@ -743,6 +829,7 @@ func NewRecommendationViewsValue(attributeTypes map[string]attr.Type, attributes
 		TagValue:          tagValueVal,
 		Title:             titleVal,
 		Token:             tokenVal,
+		Types:             typesVal,
 		WorkspaceToken:    workspaceTokenVal,
 		state:             attr.ValueStateKnown,
 	}, diags
@@ -816,25 +903,27 @@ func (t RecommendationViewsType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = RecommendationViewsValue{}
 
 type RecommendationViewsValue struct {
-	AccountIds        basetypes.ListValue   `tfsdk:"account_ids"`
-	BillingAccountIds basetypes.ListValue   `tfsdk:"billing_account_ids"`
-	CreatedAt         basetypes.StringValue `tfsdk:"created_at"`
-	CreatedBy         basetypes.StringValue `tfsdk:"created_by"`
-	EndDate           basetypes.StringValue `tfsdk:"end_date"`
-	Id                basetypes.StringValue `tfsdk:"id"`
-	ProviderIds       basetypes.ListValue   `tfsdk:"provider_ids"`
-	Regions           basetypes.ListValue   `tfsdk:"regions"`
-	StartDate         basetypes.StringValue `tfsdk:"start_date"`
-	TagKey            basetypes.StringValue `tfsdk:"tag_key"`
-	TagValue          basetypes.StringValue `tfsdk:"tag_value"`
-	Title             basetypes.StringValue `tfsdk:"title"`
-	Token             basetypes.StringValue `tfsdk:"token"`
-	WorkspaceToken    basetypes.StringValue `tfsdk:"workspace_token"`
+	AccountIds        basetypes.ListValue    `tfsdk:"account_ids"`
+	BillingAccountIds basetypes.ListValue    `tfsdk:"billing_account_ids"`
+	CreatedAt         basetypes.StringValue  `tfsdk:"created_at"`
+	CreatedBy         basetypes.StringValue  `tfsdk:"created_by"`
+	EndDate           basetypes.StringValue  `tfsdk:"end_date"`
+	Id                basetypes.StringValue  `tfsdk:"id"`
+	MinSavings        basetypes.Float64Value `tfsdk:"min_savings"`
+	ProviderIds       basetypes.ListValue    `tfsdk:"provider_ids"`
+	Regions           basetypes.ListValue    `tfsdk:"regions"`
+	StartDate         basetypes.StringValue  `tfsdk:"start_date"`
+	TagKey            basetypes.StringValue  `tfsdk:"tag_key"`
+	TagValue          basetypes.StringValue  `tfsdk:"tag_value"`
+	Title             basetypes.StringValue  `tfsdk:"title"`
+	Token             basetypes.StringValue  `tfsdk:"token"`
+	Types             basetypes.ListValue    `tfsdk:"types"`
+	WorkspaceToken    basetypes.StringValue  `tfsdk:"workspace_token"`
 	state             attr.ValueState
 }
 
 func (v RecommendationViewsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 14)
+	attrTypes := make(map[string]tftypes.Type, 16)
 
 	var val tftypes.Value
 	var err error
@@ -849,6 +938,7 @@ func (v RecommendationViewsValue) ToTerraformValue(ctx context.Context) (tftypes
 	attrTypes["created_by"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["end_date"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["min_savings"] = basetypes.Float64Type{}.TerraformType(ctx)
 	attrTypes["provider_ids"] = basetypes.ListType{
 		ElemType: types.StringType,
 	}.TerraformType(ctx)
@@ -860,13 +950,16 @@ func (v RecommendationViewsValue) ToTerraformValue(ctx context.Context) (tftypes
 	attrTypes["tag_value"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["title"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["token"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["types"] = basetypes.ListType{
+		ElemType: types.StringType,
+	}.TerraformType(ctx)
 	attrTypes["workspace_token"] = basetypes.StringType{}.TerraformType(ctx)
 
 	objectType := tftypes.Object{AttributeTypes: attrTypes}
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 14)
+		vals := make(map[string]tftypes.Value, 16)
 
 		val, err = v.AccountIds.ToTerraformValue(ctx)
 
@@ -915,6 +1008,14 @@ func (v RecommendationViewsValue) ToTerraformValue(ctx context.Context) (tftypes
 		}
 
 		vals["id"] = val
+
+		val, err = v.MinSavings.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["min_savings"] = val
 
 		val, err = v.ProviderIds.ToTerraformValue(ctx)
 
@@ -971,6 +1072,14 @@ func (v RecommendationViewsValue) ToTerraformValue(ctx context.Context) (tftypes
 		}
 
 		vals["token"] = val
+
+		val, err = v.Types.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["types"] = val
 
 		val, err = v.WorkspaceToken.ToTerraformValue(ctx)
 
@@ -1029,21 +1138,25 @@ func (v RecommendationViewsValue) ToObjectValue(ctx context.Context) (basetypes.
 			"billing_account_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"created_at": basetypes.StringType{},
-			"created_by": basetypes.StringType{},
-			"end_date":   basetypes.StringType{},
-			"id":         basetypes.StringType{},
+			"created_at":  basetypes.StringType{},
+			"created_by":  basetypes.StringType{},
+			"end_date":    basetypes.StringType{},
+			"id":          basetypes.StringType{},
+			"min_savings": basetypes.Float64Type{},
 			"provider_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
 			"regions": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"start_date":      basetypes.StringType{},
-			"tag_key":         basetypes.StringType{},
-			"tag_value":       basetypes.StringType{},
-			"title":           basetypes.StringType{},
-			"token":           basetypes.StringType{},
+			"start_date": basetypes.StringType{},
+			"tag_key":    basetypes.StringType{},
+			"tag_value":  basetypes.StringType{},
+			"title":      basetypes.StringType{},
+			"token":      basetypes.StringType{},
+			"types": basetypes.ListType{
+				ElemType: types.StringType,
+			},
 			"workspace_token": basetypes.StringType{},
 		}), diags
 	}
@@ -1068,21 +1181,25 @@ func (v RecommendationViewsValue) ToObjectValue(ctx context.Context) (basetypes.
 			"billing_account_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"created_at": basetypes.StringType{},
-			"created_by": basetypes.StringType{},
-			"end_date":   basetypes.StringType{},
-			"id":         basetypes.StringType{},
+			"created_at":  basetypes.StringType{},
+			"created_by":  basetypes.StringType{},
+			"end_date":    basetypes.StringType{},
+			"id":          basetypes.StringType{},
+			"min_savings": basetypes.Float64Type{},
 			"provider_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
 			"regions": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"start_date":      basetypes.StringType{},
-			"tag_key":         basetypes.StringType{},
-			"tag_value":       basetypes.StringType{},
-			"title":           basetypes.StringType{},
-			"token":           basetypes.StringType{},
+			"start_date": basetypes.StringType{},
+			"tag_key":    basetypes.StringType{},
+			"tag_value":  basetypes.StringType{},
+			"title":      basetypes.StringType{},
+			"token":      basetypes.StringType{},
+			"types": basetypes.ListType{
+				ElemType: types.StringType,
+			},
 			"workspace_token": basetypes.StringType{},
 		}), diags
 	}
@@ -1107,21 +1224,25 @@ func (v RecommendationViewsValue) ToObjectValue(ctx context.Context) (basetypes.
 			"billing_account_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"created_at": basetypes.StringType{},
-			"created_by": basetypes.StringType{},
-			"end_date":   basetypes.StringType{},
-			"id":         basetypes.StringType{},
+			"created_at":  basetypes.StringType{},
+			"created_by":  basetypes.StringType{},
+			"end_date":    basetypes.StringType{},
+			"id":          basetypes.StringType{},
+			"min_savings": basetypes.Float64Type{},
 			"provider_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
 			"regions": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"start_date":      basetypes.StringType{},
-			"tag_key":         basetypes.StringType{},
-			"tag_value":       basetypes.StringType{},
-			"title":           basetypes.StringType{},
-			"token":           basetypes.StringType{},
+			"start_date": basetypes.StringType{},
+			"tag_key":    basetypes.StringType{},
+			"tag_value":  basetypes.StringType{},
+			"title":      basetypes.StringType{},
+			"token":      basetypes.StringType{},
+			"types": basetypes.ListType{
+				ElemType: types.StringType,
+			},
 			"workspace_token": basetypes.StringType{},
 		}), diags
 	}
@@ -1146,21 +1267,68 @@ func (v RecommendationViewsValue) ToObjectValue(ctx context.Context) (basetypes.
 			"billing_account_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"created_at": basetypes.StringType{},
-			"created_by": basetypes.StringType{},
-			"end_date":   basetypes.StringType{},
-			"id":         basetypes.StringType{},
+			"created_at":  basetypes.StringType{},
+			"created_by":  basetypes.StringType{},
+			"end_date":    basetypes.StringType{},
+			"id":          basetypes.StringType{},
+			"min_savings": basetypes.Float64Type{},
 			"provider_ids": basetypes.ListType{
 				ElemType: types.StringType,
 			},
 			"regions": basetypes.ListType{
 				ElemType: types.StringType,
 			},
-			"start_date":      basetypes.StringType{},
-			"tag_key":         basetypes.StringType{},
-			"tag_value":       basetypes.StringType{},
-			"title":           basetypes.StringType{},
-			"token":           basetypes.StringType{},
+			"start_date": basetypes.StringType{},
+			"tag_key":    basetypes.StringType{},
+			"tag_value":  basetypes.StringType{},
+			"title":      basetypes.StringType{},
+			"token":      basetypes.StringType{},
+			"types": basetypes.ListType{
+				ElemType: types.StringType,
+			},
+			"workspace_token": basetypes.StringType{},
+		}), diags
+	}
+
+	var typesVal basetypes.ListValue
+	switch {
+	case v.Types.IsUnknown():
+		typesVal = types.ListUnknown(types.StringType)
+	case v.Types.IsNull():
+		typesVal = types.ListNull(types.StringType)
+	default:
+		var d diag.Diagnostics
+		typesVal, d = types.ListValue(types.StringType, v.Types.Elements())
+		diags.Append(d...)
+	}
+
+	if diags.HasError() {
+		return types.ObjectUnknown(map[string]attr.Type{
+			"account_ids": basetypes.ListType{
+				ElemType: types.StringType,
+			},
+			"billing_account_ids": basetypes.ListType{
+				ElemType: types.StringType,
+			},
+			"created_at":  basetypes.StringType{},
+			"created_by":  basetypes.StringType{},
+			"end_date":    basetypes.StringType{},
+			"id":          basetypes.StringType{},
+			"min_savings": basetypes.Float64Type{},
+			"provider_ids": basetypes.ListType{
+				ElemType: types.StringType,
+			},
+			"regions": basetypes.ListType{
+				ElemType: types.StringType,
+			},
+			"start_date": basetypes.StringType{},
+			"tag_key":    basetypes.StringType{},
+			"tag_value":  basetypes.StringType{},
+			"title":      basetypes.StringType{},
+			"token":      basetypes.StringType{},
+			"types": basetypes.ListType{
+				ElemType: types.StringType,
+			},
 			"workspace_token": basetypes.StringType{},
 		}), diags
 	}
@@ -1172,21 +1340,25 @@ func (v RecommendationViewsValue) ToObjectValue(ctx context.Context) (basetypes.
 		"billing_account_ids": basetypes.ListType{
 			ElemType: types.StringType,
 		},
-		"created_at": basetypes.StringType{},
-		"created_by": basetypes.StringType{},
-		"end_date":   basetypes.StringType{},
-		"id":         basetypes.StringType{},
+		"created_at":  basetypes.StringType{},
+		"created_by":  basetypes.StringType{},
+		"end_date":    basetypes.StringType{},
+		"id":          basetypes.StringType{},
+		"min_savings": basetypes.Float64Type{},
 		"provider_ids": basetypes.ListType{
 			ElemType: types.StringType,
 		},
 		"regions": basetypes.ListType{
 			ElemType: types.StringType,
 		},
-		"start_date":      basetypes.StringType{},
-		"tag_key":         basetypes.StringType{},
-		"tag_value":       basetypes.StringType{},
-		"title":           basetypes.StringType{},
-		"token":           basetypes.StringType{},
+		"start_date": basetypes.StringType{},
+		"tag_key":    basetypes.StringType{},
+		"tag_value":  basetypes.StringType{},
+		"title":      basetypes.StringType{},
+		"token":      basetypes.StringType{},
+		"types": basetypes.ListType{
+			ElemType: types.StringType,
+		},
 		"workspace_token": basetypes.StringType{},
 	}
 
@@ -1207,6 +1379,7 @@ func (v RecommendationViewsValue) ToObjectValue(ctx context.Context) (basetypes.
 			"created_by":          v.CreatedBy,
 			"end_date":            v.EndDate,
 			"id":                  v.Id,
+			"min_savings":         v.MinSavings,
 			"provider_ids":        providerIdsVal,
 			"regions":             regionsVal,
 			"start_date":          v.StartDate,
@@ -1214,6 +1387,7 @@ func (v RecommendationViewsValue) ToObjectValue(ctx context.Context) (basetypes.
 			"tag_value":           v.TagValue,
 			"title":               v.Title,
 			"token":               v.Token,
+			"types":               typesVal,
 			"workspace_token":     v.WorkspaceToken,
 		})
 
@@ -1259,6 +1433,10 @@ func (v RecommendationViewsValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.MinSavings.Equal(other.MinSavings) {
+		return false
+	}
+
 	if !v.ProviderIds.Equal(other.ProviderIds) {
 		return false
 	}
@@ -1287,6 +1465,10 @@ func (v RecommendationViewsValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.Types.Equal(other.Types) {
+		return false
+	}
+
 	if !v.WorkspaceToken.Equal(other.WorkspaceToken) {
 		return false
 	}
@@ -1310,21 +1492,25 @@ func (v RecommendationViewsValue) AttributeTypes(ctx context.Context) map[string
 		"billing_account_ids": basetypes.ListType{
 			ElemType: types.StringType,
 		},
-		"created_at": basetypes.StringType{},
-		"created_by": basetypes.StringType{},
-		"end_date":   basetypes.StringType{},
-		"id":         basetypes.StringType{},
+		"created_at":  basetypes.StringType{},
+		"created_by":  basetypes.StringType{},
+		"end_date":    basetypes.StringType{},
+		"id":          basetypes.StringType{},
+		"min_savings": basetypes.Float64Type{},
 		"provider_ids": basetypes.ListType{
 			ElemType: types.StringType,
 		},
 		"regions": basetypes.ListType{
 			ElemType: types.StringType,
 		},
-		"start_date":      basetypes.StringType{},
-		"tag_key":         basetypes.StringType{},
-		"tag_value":       basetypes.StringType{},
-		"title":           basetypes.StringType{},
-		"token":           basetypes.StringType{},
+		"start_date": basetypes.StringType{},
+		"tag_key":    basetypes.StringType{},
+		"tag_value":  basetypes.StringType{},
+		"title":      basetypes.StringType{},
+		"token":      basetypes.StringType{},
+		"types": basetypes.ListType{
+			ElemType: types.StringType,
+		},
 		"workspace_token": basetypes.StringType{},
 	}
 }

--- a/vantage/datasource_virtual_tag_configs/virtual_tag_configs_data_source_gen.go
+++ b/vantage/datasource_virtual_tag_configs/virtual_tag_configs_data_source_gen.go
@@ -18,6 +18,12 @@ import (
 func VirtualTagConfigsDataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"q": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "A search query to filter VirtualTagConfigs by key.",
+				MarkdownDescription: "A search query to filter VirtualTagConfigs by key.",
+			},
 			"virtual_tag_configs": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -31,8 +37,8 @@ func VirtualTagConfigsDataSourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"filter": schema.StringAttribute{
 										Computed:            true,
-										Description:         "The VQL filter this collapsed tag key applies to.",
-										MarkdownDescription: "The VQL filter this collapsed tag key applies to.",
+										Description:         "The VQL filter this collapsed tag key applies to. Null when the key is provider-scoped or unset.",
+										MarkdownDescription: "The VQL filter this collapsed tag key applies to. Null when the key is provider-scoped or unset.",
 									},
 									"key": schema.StringAttribute{
 										Computed:            true,
@@ -42,8 +48,8 @@ func VirtualTagConfigsDataSourceSchema(ctx context.Context) schema.Schema {
 									"providers": schema.ListAttribute{
 										ElementType:         types.StringType,
 										Computed:            true,
-										Description:         "The providers this collapsed tag key applies to. Defaults to all providers when omitted.",
-										MarkdownDescription: "The providers this collapsed tag key applies to. Defaults to all providers when omitted.",
+										Description:         "The providers this collapsed tag key applies to. Empty when it applies to all providers.",
+										MarkdownDescription: "The providers this collapsed tag key applies to. Empty when it applies to all providers.",
 									},
 								},
 								CustomType: CollapsedTagKeysType{
@@ -241,7 +247,8 @@ func VirtualTagConfigsDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type VirtualTagConfigsModel struct {
-	VirtualTagConfigs types.List `tfsdk:"virtual_tag_configs"`
+	Q                 types.String `tfsdk:"q"`
+	VirtualTagConfigs types.List   `tfsdk:"virtual_tag_configs"`
 }
 
 var _ basetypes.ObjectTypable = VirtualTagConfigsType{}

--- a/vantage/resource_business_metric/business_metric_resource_gen.go
+++ b/vantage/resource_business_metric/business_metric_resource_gen.go
@@ -96,10 +96,20 @@ func BusinessMetricResourceSchema(ctx context.Context) schema.Schema {
 			"cost_report_tokens_with_metadata": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"calculation_type": schema.StringAttribute{
+							Computed:            true,
+							Description:         "The calculation type applied when this BusinessMetric is used in the CostReport.",
+							MarkdownDescription: "The calculation type applied when this BusinessMetric is used in the CostReport.",
+						},
 						"cost_report_token": schema.StringAttribute{
 							Required:            true,
 							Description:         "The token of the CostReport the BusinessMetric is attached to.",
 							MarkdownDescription: "The token of the CostReport the BusinessMetric is attached to.",
+						},
+						"label": schema.StringAttribute{
+							Computed:            true,
+							Description:         "Optional custom display name for this BusinessMetric on the CostReport. When omitted, a default is derived from the calculation type.",
+							MarkdownDescription: "Optional custom display name for this BusinessMetric on the CostReport. When omitted, a default is derived from the calculation type.",
 						},
 						"label_filter": schema.ListAttribute{
 							ElementType:         types.StringType,
@@ -107,6 +117,15 @@ func BusinessMetricResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "Include only values with these labels in the CostReport.",
 							MarkdownDescription: "Include only values with these labels in the CostReport.",
+						},
+						"label_filters": schema.MapAttribute{
+							ElementType: types.ListType{
+								ElemType: types.StringType,
+							},
+							Optional:            true,
+							Computed:            true,
+							Description:         "Include only ClickHouse BusinessMetric values matching every label key and one of its values.",
+							MarkdownDescription: "Include only ClickHouse BusinessMetric values matching every label key and one of its values.",
 						},
 						"unit_scale": schema.StringAttribute{
 							Optional:            true,
@@ -206,6 +225,31 @@ func BusinessMetricResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The Integration token used to import the BusinessMetric.",
 				MarkdownDescription: "The Integration token used to import the BusinessMetric.",
 			},
+			"snowflake_metric_fields": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"integration_token": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Integration token for the Snowflake integration from which you would like to fetch metrics.",
+						MarkdownDescription: "Integration token for the Snowflake integration from which you would like to fetch metrics.",
+					},
+					"sql_query": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Snowflake SQL query returning date, value, and optional label columns.",
+						MarkdownDescription: "Snowflake SQL query returning date, value, and optional label columns.",
+					},
+				},
+				CustomType: SnowflakeMetricFieldsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: SnowflakeMetricFieldsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Snowflake metric configuration fields.",
+				MarkdownDescription: "Snowflake metric configuration fields.",
+			},
 			"title": schema.StringAttribute{
 				Required:            true,
 				Description:         "The title of the BusinessMetrics.",
@@ -246,17 +290,18 @@ func BusinessMetricResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type BusinessMetricModel struct {
-	CloudwatchFields             CloudwatchFieldsValue    `tfsdk:"cloudwatch_fields"`
-	CostReportTokensWithMetadata types.List               `tfsdk:"cost_report_tokens_with_metadata"`
-	CreatedByToken               types.String             `tfsdk:"created_by_token"`
-	DatadogMetricFields          DatadogMetricFieldsValue `tfsdk:"datadog_metric_fields"`
-	ForecastedValues             types.List               `tfsdk:"forecasted_values"`
-	Id                           types.String             `tfsdk:"id"`
-	ImportType                   types.String             `tfsdk:"import_type"`
-	IntegrationToken             types.String             `tfsdk:"integration_token"`
-	Title                        types.String             `tfsdk:"title"`
-	Token                        types.String             `tfsdk:"token"`
-	Values                       types.List               `tfsdk:"values"`
+	CloudwatchFields             CloudwatchFieldsValue      `tfsdk:"cloudwatch_fields"`
+	CostReportTokensWithMetadata types.List                 `tfsdk:"cost_report_tokens_with_metadata"`
+	CreatedByToken               types.String               `tfsdk:"created_by_token"`
+	DatadogMetricFields          DatadogMetricFieldsValue   `tfsdk:"datadog_metric_fields"`
+	ForecastedValues             types.List                 `tfsdk:"forecasted_values"`
+	Id                           types.String               `tfsdk:"id"`
+	ImportType                   types.String               `tfsdk:"import_type"`
+	IntegrationToken             types.String               `tfsdk:"integration_token"`
+	SnowflakeMetricFields        SnowflakeMetricFieldsValue `tfsdk:"snowflake_metric_fields"`
+	Title                        types.String               `tfsdk:"title"`
+	Token                        types.String               `tfsdk:"token"`
+	Values                       types.List                 `tfsdk:"values"`
 }
 
 var _ basetypes.ObjectTypable = CloudwatchFieldsType{}
@@ -1352,6 +1397,24 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 
 	attributes := in.Attributes()
 
+	calculationTypeAttribute, ok := attributes["calculation_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`calculation_type is missing from object`)
+
+		return nil, diags
+	}
+
+	calculationTypeVal, ok := calculationTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`calculation_type expected to be basetypes.StringValue, was: %T`, calculationTypeAttribute))
+	}
+
 	costReportTokenAttribute, ok := attributes["cost_report_token"]
 
 	if !ok {
@@ -1370,6 +1433,24 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 			fmt.Sprintf(`cost_report_token expected to be basetypes.StringValue, was: %T`, costReportTokenAttribute))
 	}
 
+	labelAttribute, ok := attributes["label"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label is missing from object`)
+
+		return nil, diags
+	}
+
+	labelVal, ok := labelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label expected to be basetypes.StringValue, was: %T`, labelAttribute))
+	}
+
 	labelFilterAttribute, ok := attributes["label_filter"]
 
 	if !ok {
@@ -1386,6 +1467,24 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 		diags.AddError(
 			"Attribute Wrong Type",
 			fmt.Sprintf(`label_filter expected to be basetypes.ListValue, was: %T`, labelFilterAttribute))
+	}
+
+	labelFiltersAttribute, ok := attributes["label_filters"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_filters is missing from object`)
+
+		return nil, diags
+	}
+
+	labelFiltersVal, ok := labelFiltersAttribute.(basetypes.MapValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_filters expected to be basetypes.MapValue, was: %T`, labelFiltersAttribute))
 	}
 
 	unitScaleAttribute, ok := attributes["unit_scale"]
@@ -1411,8 +1510,11 @@ func (t CostReportTokensWithMetadataType) ValueFromObject(ctx context.Context, i
 	}
 
 	return CostReportTokensWithMetadataValue{
+		CalculationType: calculationTypeVal,
 		CostReportToken: costReportTokenVal,
+		Label:           labelVal,
 		LabelFilter:     labelFilterVal,
+		LabelFilters:    labelFiltersVal,
 		UnitScale:       unitScaleVal,
 		state:           attr.ValueStateKnown,
 	}, diags
@@ -1481,6 +1583,24 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 		return NewCostReportTokensWithMetadataValueUnknown(), diags
 	}
 
+	calculationTypeAttribute, ok := attributes["calculation_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`calculation_type is missing from object`)
+
+		return NewCostReportTokensWithMetadataValueUnknown(), diags
+	}
+
+	calculationTypeVal, ok := calculationTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`calculation_type expected to be basetypes.StringValue, was: %T`, calculationTypeAttribute))
+	}
+
 	costReportTokenAttribute, ok := attributes["cost_report_token"]
 
 	if !ok {
@@ -1499,6 +1619,24 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 			fmt.Sprintf(`cost_report_token expected to be basetypes.StringValue, was: %T`, costReportTokenAttribute))
 	}
 
+	labelAttribute, ok := attributes["label"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label is missing from object`)
+
+		return NewCostReportTokensWithMetadataValueUnknown(), diags
+	}
+
+	labelVal, ok := labelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label expected to be basetypes.StringValue, was: %T`, labelAttribute))
+	}
+
 	labelFilterAttribute, ok := attributes["label_filter"]
 
 	if !ok {
@@ -1515,6 +1653,24 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 		diags.AddError(
 			"Attribute Wrong Type",
 			fmt.Sprintf(`label_filter expected to be basetypes.ListValue, was: %T`, labelFilterAttribute))
+	}
+
+	labelFiltersAttribute, ok := attributes["label_filters"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`label_filters is missing from object`)
+
+		return NewCostReportTokensWithMetadataValueUnknown(), diags
+	}
+
+	labelFiltersVal, ok := labelFiltersAttribute.(basetypes.MapValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`label_filters expected to be basetypes.MapValue, was: %T`, labelFiltersAttribute))
 	}
 
 	unitScaleAttribute, ok := attributes["unit_scale"]
@@ -1540,8 +1696,11 @@ func NewCostReportTokensWithMetadataValue(attributeTypes map[string]attr.Type, a
 	}
 
 	return CostReportTokensWithMetadataValue{
+		CalculationType: calculationTypeVal,
 		CostReportToken: costReportTokenVal,
+		Label:           labelVal,
 		LabelFilter:     labelFilterVal,
+		LabelFilters:    labelFiltersVal,
 		UnitScale:       unitScaleVal,
 		state:           attr.ValueStateKnown,
 	}, diags
@@ -1615,21 +1774,31 @@ func (t CostReportTokensWithMetadataType) ValueType(ctx context.Context) attr.Va
 var _ basetypes.ObjectValuable = CostReportTokensWithMetadataValue{}
 
 type CostReportTokensWithMetadataValue struct {
+	CalculationType basetypes.StringValue `tfsdk:"calculation_type"`
 	CostReportToken basetypes.StringValue `tfsdk:"cost_report_token"`
+	Label           basetypes.StringValue `tfsdk:"label"`
 	LabelFilter     basetypes.ListValue   `tfsdk:"label_filter"`
+	LabelFilters    basetypes.MapValue    `tfsdk:"label_filters"`
 	UnitScale       basetypes.StringValue `tfsdk:"unit_scale"`
 	state           attr.ValueState
 }
 
 func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 3)
+	attrTypes := make(map[string]tftypes.Type, 6)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["calculation_type"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["cost_report_token"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["label"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["label_filter"] = basetypes.ListType{
 		ElemType: types.StringType,
+	}.TerraformType(ctx)
+	attrTypes["label_filters"] = basetypes.MapType{
+		ElemType: types.ListType{
+			ElemType: types.StringType,
+		},
 	}.TerraformType(ctx)
 	attrTypes["unit_scale"] = basetypes.StringType{}.TerraformType(ctx)
 
@@ -1637,7 +1806,15 @@ func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context)
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 3)
+		vals := make(map[string]tftypes.Value, 6)
+
+		val, err = v.CalculationType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["calculation_type"] = val
 
 		val, err = v.CostReportToken.ToTerraformValue(ctx)
 
@@ -1647,6 +1824,14 @@ func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context)
 
 		vals["cost_report_token"] = val
 
+		val, err = v.Label.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["label"] = val
+
 		val, err = v.LabelFilter.ToTerraformValue(ctx)
 
 		if err != nil {
@@ -1654,6 +1839,14 @@ func (v CostReportTokensWithMetadataValue) ToTerraformValue(ctx context.Context)
 		}
 
 		vals["label_filter"] = val
+
+		val, err = v.LabelFilters.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["label_filters"] = val
 
 		val, err = v.UnitScale.ToTerraformValue(ctx)
 
@@ -1706,18 +1899,67 @@ func (v CostReportTokensWithMetadataValue) ToObjectValue(ctx context.Context) (b
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
+			"calculation_type":  basetypes.StringType{},
 			"cost_report_token": basetypes.StringType{},
+			"label":             basetypes.StringType{},
 			"label_filter": basetypes.ListType{
 				ElemType: types.StringType,
+			},
+			"label_filters": basetypes.MapType{
+				ElemType: types.ListType{
+					ElemType: types.StringType,
+				},
+			},
+			"unit_scale": basetypes.StringType{},
+		}), diags
+	}
+
+	var labelFiltersVal basetypes.MapValue
+	switch {
+	case v.LabelFilters.IsUnknown():
+		labelFiltersVal = types.MapUnknown(types.ListType{
+			ElemType: types.StringType,
+		})
+	case v.LabelFilters.IsNull():
+		labelFiltersVal = types.MapNull(types.ListType{
+			ElemType: types.StringType,
+		})
+	default:
+		var d diag.Diagnostics
+		labelFiltersVal, d = types.MapValue(types.ListType{
+			ElemType: types.StringType,
+		}, v.LabelFilters.Elements())
+		diags.Append(d...)
+	}
+
+	if diags.HasError() {
+		return types.ObjectUnknown(map[string]attr.Type{
+			"calculation_type":  basetypes.StringType{},
+			"cost_report_token": basetypes.StringType{},
+			"label":             basetypes.StringType{},
+			"label_filter": basetypes.ListType{
+				ElemType: types.StringType,
+			},
+			"label_filters": basetypes.MapType{
+				ElemType: types.ListType{
+					ElemType: types.StringType,
+				},
 			},
 			"unit_scale": basetypes.StringType{},
 		}), diags
 	}
 
 	attributeTypes := map[string]attr.Type{
+		"calculation_type":  basetypes.StringType{},
 		"cost_report_token": basetypes.StringType{},
+		"label":             basetypes.StringType{},
 		"label_filter": basetypes.ListType{
 			ElemType: types.StringType,
+		},
+		"label_filters": basetypes.MapType{
+			ElemType: types.ListType{
+				ElemType: types.StringType,
+			},
 		},
 		"unit_scale": basetypes.StringType{},
 	}
@@ -1733,8 +1975,11 @@ func (v CostReportTokensWithMetadataValue) ToObjectValue(ctx context.Context) (b
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
+			"calculation_type":  v.CalculationType,
 			"cost_report_token": v.CostReportToken,
+			"label":             v.Label,
 			"label_filter":      labelFilterVal,
+			"label_filters":     labelFiltersVal,
 			"unit_scale":        v.UnitScale,
 		})
 
@@ -1756,11 +2001,23 @@ func (v CostReportTokensWithMetadataValue) Equal(o attr.Value) bool {
 		return true
 	}
 
+	if !v.CalculationType.Equal(other.CalculationType) {
+		return false
+	}
+
 	if !v.CostReportToken.Equal(other.CostReportToken) {
 		return false
 	}
 
+	if !v.Label.Equal(other.Label) {
+		return false
+	}
+
 	if !v.LabelFilter.Equal(other.LabelFilter) {
+		return false
+	}
+
+	if !v.LabelFilters.Equal(other.LabelFilters) {
 		return false
 	}
 
@@ -1781,9 +2038,16 @@ func (v CostReportTokensWithMetadataValue) Type(ctx context.Context) attr.Type {
 
 func (v CostReportTokensWithMetadataValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
+		"calculation_type":  basetypes.StringType{},
 		"cost_report_token": basetypes.StringType{},
+		"label":             basetypes.StringType{},
 		"label_filter": basetypes.ListType{
 			ElemType: types.StringType,
+		},
+		"label_filters": basetypes.MapType{
+			ElemType: types.ListType{
+				ElemType: types.StringType,
+			},
 		},
 		"unit_scale": basetypes.StringType{},
 	}
@@ -2599,6 +2863,385 @@ func (v ForecastedValuesValue) AttributeTypes(ctx context.Context) map[string]at
 		"amount": basetypes.Float64Type{},
 		"date":   basetypes.StringType{},
 		"label":  basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = SnowflakeMetricFieldsType{}
+
+type SnowflakeMetricFieldsType struct {
+	basetypes.ObjectType
+}
+
+func (t SnowflakeMetricFieldsType) Equal(o attr.Type) bool {
+	other, ok := o.(SnowflakeMetricFieldsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t SnowflakeMetricFieldsType) String() string {
+	return "SnowflakeMetricFieldsType"
+}
+
+func (t SnowflakeMetricFieldsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	integrationTokenAttribute, ok := attributes["integration_token"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`integration_token is missing from object`)
+
+		return nil, diags
+	}
+
+	integrationTokenVal, ok := integrationTokenAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`integration_token expected to be basetypes.StringValue, was: %T`, integrationTokenAttribute))
+	}
+
+	sqlQueryAttribute, ok := attributes["sql_query"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`sql_query is missing from object`)
+
+		return nil, diags
+	}
+
+	sqlQueryVal, ok := sqlQueryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`sql_query expected to be basetypes.StringValue, was: %T`, sqlQueryAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return SnowflakeMetricFieldsValue{
+		IntegrationToken: integrationTokenVal,
+		SqlQuery:         sqlQueryVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewSnowflakeMetricFieldsValueNull() SnowflakeMetricFieldsValue {
+	return SnowflakeMetricFieldsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewSnowflakeMetricFieldsValueUnknown() SnowflakeMetricFieldsValue {
+	return SnowflakeMetricFieldsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewSnowflakeMetricFieldsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (SnowflakeMetricFieldsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing SnowflakeMetricFieldsValue Attribute Value",
+				"While creating a SnowflakeMetricFieldsValue value, a missing attribute value was detected. "+
+					"A SnowflakeMetricFieldsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("SnowflakeMetricFieldsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid SnowflakeMetricFieldsValue Attribute Type",
+				"While creating a SnowflakeMetricFieldsValue value, an invalid attribute value was detected. "+
+					"A SnowflakeMetricFieldsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("SnowflakeMetricFieldsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("SnowflakeMetricFieldsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra SnowflakeMetricFieldsValue Attribute Value",
+				"While creating a SnowflakeMetricFieldsValue value, an extra attribute value was detected. "+
+					"A SnowflakeMetricFieldsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra SnowflakeMetricFieldsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewSnowflakeMetricFieldsValueUnknown(), diags
+	}
+
+	integrationTokenAttribute, ok := attributes["integration_token"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`integration_token is missing from object`)
+
+		return NewSnowflakeMetricFieldsValueUnknown(), diags
+	}
+
+	integrationTokenVal, ok := integrationTokenAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`integration_token expected to be basetypes.StringValue, was: %T`, integrationTokenAttribute))
+	}
+
+	sqlQueryAttribute, ok := attributes["sql_query"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`sql_query is missing from object`)
+
+		return NewSnowflakeMetricFieldsValueUnknown(), diags
+	}
+
+	sqlQueryVal, ok := sqlQueryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`sql_query expected to be basetypes.StringValue, was: %T`, sqlQueryAttribute))
+	}
+
+	if diags.HasError() {
+		return NewSnowflakeMetricFieldsValueUnknown(), diags
+	}
+
+	return SnowflakeMetricFieldsValue{
+		IntegrationToken: integrationTokenVal,
+		SqlQuery:         sqlQueryVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewSnowflakeMetricFieldsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) SnowflakeMetricFieldsValue {
+	object, diags := NewSnowflakeMetricFieldsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewSnowflakeMetricFieldsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t SnowflakeMetricFieldsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewSnowflakeMetricFieldsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewSnowflakeMetricFieldsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewSnowflakeMetricFieldsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewSnowflakeMetricFieldsValueMust(SnowflakeMetricFieldsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t SnowflakeMetricFieldsType) ValueType(ctx context.Context) attr.Value {
+	return SnowflakeMetricFieldsValue{}
+}
+
+var _ basetypes.ObjectValuable = SnowflakeMetricFieldsValue{}
+
+type SnowflakeMetricFieldsValue struct {
+	IntegrationToken basetypes.StringValue `tfsdk:"integration_token"`
+	SqlQuery         basetypes.StringValue `tfsdk:"sql_query"`
+	state            attr.ValueState
+}
+
+func (v SnowflakeMetricFieldsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["integration_token"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["sql_query"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.IntegrationToken.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["integration_token"] = val
+
+		val, err = v.SqlQuery.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["sql_query"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v SnowflakeMetricFieldsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v SnowflakeMetricFieldsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v SnowflakeMetricFieldsValue) String() string {
+	return "SnowflakeMetricFieldsValue"
+}
+
+func (v SnowflakeMetricFieldsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"integration_token": basetypes.StringType{},
+		"sql_query":         basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"integration_token": v.IntegrationToken,
+			"sql_query":         v.SqlQuery,
+		})
+
+	return objVal, diags
+}
+
+func (v SnowflakeMetricFieldsValue) Equal(o attr.Value) bool {
+	other, ok := o.(SnowflakeMetricFieldsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.IntegrationToken.Equal(other.IntegrationToken) {
+		return false
+	}
+
+	if !v.SqlQuery.Equal(other.SqlQuery) {
+		return false
+	}
+
+	return true
+}
+
+func (v SnowflakeMetricFieldsValue) Type(ctx context.Context) attr.Type {
+	return SnowflakeMetricFieldsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v SnowflakeMetricFieldsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"integration_token": basetypes.StringType{},
+		"sql_query":         basetypes.StringType{},
 	}
 }
 

--- a/vantage/resource_dashboard/dashboard_resource_gen.go
+++ b/vantage/resource_dashboard/dashboard_resource_gen.go
@@ -145,8 +145,8 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 				},
 				Optional:            true,
 				Computed:            true,
-				Description:         "The widgets to add to the Dashboard. Currently supports CostReport, ResourceReport, KubernetesEfficiencyReport, and FinancialCommitmentReport.",
-				MarkdownDescription: "The widgets to add to the Dashboard. Currently supports CostReport, ResourceReport, KubernetesEfficiencyReport, and FinancialCommitmentReport.",
+				Description:         "The widgets to add to the Dashboard. Currently supports CostReport, ResourceReport, KubernetesEfficiencyReport, FinancialCommitmentReport, and RecommendationView.",
+				MarkdownDescription: "The widgets to add to the Dashboard. Currently supports CostReport, ResourceReport, KubernetesEfficiencyReport, FinancialCommitmentReport, and RecommendationView.",
 			},
 			"workspace_token": schema.StringAttribute{
 				Optional:            true,

--- a/vantage/resource_kubernetes_efficiency_report/kubernetes_efficiency_report_resource_gen.go
+++ b/vantage/resource_kubernetes_efficiency_report/kubernetes_efficiency_report_resource_gen.go
@@ -94,8 +94,8 @@ func KubernetesEfficiencyReportResourceSchema(ctx context.Context) schema.Schema
 				ElementType:         types.StringType,
 				Optional:            true,
 				Computed:            true,
-				Description:         "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, labeled, category, pod, label, label:<label_name>.",
-				MarkdownDescription: "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, labeled, category, pod, label, label:<label_name>.",
+				Description:         "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, region, labeled, category, pod, label, label:<label_name>.",
+				MarkdownDescription: "Grouping values for aggregating costs on the KubernetesEfficiencyReport. Valid groupings: cluster_id, namespace, region, labeled, category, pod, label, label:<label_name>.",
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/vantage/resource_managed_account/managed_account_resource_gen.go
+++ b/vantage/resource_managed_account/managed_account_resource_gen.go
@@ -23,8 +23,8 @@ func ManagedAccountResourceSchema(ctx context.Context) schema.Schema {
 				ElementType:         types.StringType,
 				Optional:            true,
 				Computed:            true,
-				Description:         "Billing Rule tokens to assign to the Managed Account.",
-				MarkdownDescription: "Billing Rule tokens to assign to the Managed Account.",
+				Description:         "Billing Rule tokens to assign to the Managed Account, in their desired execution order. Tokens must be ordered by execution group: AWS transforms, then COST inserts, then COST transforms, then monthly post-transform inserts. Within a group any order is accepted and persisted as-is. Submitting a list whose cross-group ordering does not match the pipeline returns a 400.Existing rules with apply_to_all enabled will be added implicity to the end of their execution group.",
+				MarkdownDescription: "Billing Rule tokens to assign to the Managed Account, in their desired execution order. Tokens must be ordered by execution group: AWS transforms, then COST inserts, then COST transforms, then monthly post-transform inserts. Within a group any order is accepted and persisted as-is. Submitting a list whose cross-group ordering does not match the pipeline returns a 400.Existing rules with apply_to_all enabled will be added implicity to the end of their execution group.",
 			},
 			"contact_email": schema.StringAttribute{
 				Required:            true,

--- a/vantage/resource_recommendation_view/recommendation_view_resource_gen.go
+++ b/vantage/resource_recommendation_view/recommendation_view_resource_gen.go
@@ -47,6 +47,12 @@ func RecommendationViewResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The id of the recommendation view",
 				MarkdownDescription: "The id of the recommendation view",
 			},
+			"min_savings": schema.Float64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Filter recommendations with at least this amount of potential savings.",
+				MarkdownDescription: "Filter recommendations with at least this amount of potential savings.",
+			},
 			"provider_ids": schema.ListAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
@@ -89,6 +95,13 @@ func RecommendationViewResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The token of the recommendation view",
 				MarkdownDescription: "The token of the recommendation view",
 			},
+			"types": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				Description:         "Filter by one or more recommendation type slugs.",
+				MarkdownDescription: "Filter by one or more recommendation type slugs.",
+			},
 			"workspace_token": schema.StringAttribute{
 				Required:            true,
 				Description:         "The Workspace to associate the RecommendationView with.",
@@ -99,18 +112,20 @@ func RecommendationViewResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type RecommendationViewModel struct {
-	AccountIds        types.List   `tfsdk:"account_ids"`
-	BillingAccountIds types.List   `tfsdk:"billing_account_ids"`
-	CreatedAt         types.String `tfsdk:"created_at"`
-	CreatedBy         types.String `tfsdk:"created_by"`
-	EndDate           types.String `tfsdk:"end_date"`
-	Id                types.String `tfsdk:"id"`
-	ProviderIds       types.List   `tfsdk:"provider_ids"`
-	Regions           types.List   `tfsdk:"regions"`
-	StartDate         types.String `tfsdk:"start_date"`
-	TagKey            types.String `tfsdk:"tag_key"`
-	TagValue          types.String `tfsdk:"tag_value"`
-	Title             types.String `tfsdk:"title"`
-	Token             types.String `tfsdk:"token"`
-	WorkspaceToken    types.String `tfsdk:"workspace_token"`
+	AccountIds        types.List    `tfsdk:"account_ids"`
+	BillingAccountIds types.List    `tfsdk:"billing_account_ids"`
+	CreatedAt         types.String  `tfsdk:"created_at"`
+	CreatedBy         types.String  `tfsdk:"created_by"`
+	EndDate           types.String  `tfsdk:"end_date"`
+	Id                types.String  `tfsdk:"id"`
+	MinSavings        types.Float64 `tfsdk:"min_savings"`
+	ProviderIds       types.List    `tfsdk:"provider_ids"`
+	Regions           types.List    `tfsdk:"regions"`
+	StartDate         types.String  `tfsdk:"start_date"`
+	TagKey            types.String  `tfsdk:"tag_key"`
+	TagValue          types.String  `tfsdk:"tag_value"`
+	Title             types.String  `tfsdk:"title"`
+	Token             types.String  `tfsdk:"token"`
+	Types             types.List    `tfsdk:"types"`
+	WorkspaceToken    types.String  `tfsdk:"workspace_token"`
 }

--- a/vantage/resource_virtual_tag_config/virtual_tag_config_resource_gen.go
+++ b/vantage/resource_virtual_tag_config/virtual_tag_config_resource_gen.go
@@ -30,8 +30,8 @@ func VirtualTagConfigResourceSchema(ctx context.Context) schema.Schema {
 						"filter": schema.StringAttribute{
 							Optional:            true,
 							Computed:            true,
-							Description:         "The VQL filter this collapsed tag key applies to.",
-							MarkdownDescription: "The VQL filter this collapsed tag key applies to.",
+							Description:         "The VQL filter this collapsed tag key applies to. When set, do not also set providers; include any provider restrictions directly in filter.",
+							MarkdownDescription: "The VQL filter this collapsed tag key applies to. When set, do not also set providers; include any provider restrictions directly in filter.",
 						},
 						"key": schema.StringAttribute{
 							Required:            true,
@@ -42,8 +42,8 @@ func VirtualTagConfigResourceSchema(ctx context.Context) schema.Schema {
 							ElementType:         types.StringType,
 							Optional:            true,
 							Computed:            true,
-							Description:         "The providers this collapsed tag key applies to. Defaults to all providers.",
-							MarkdownDescription: "The providers this collapsed tag key applies to. Defaults to all providers.",
+							Description:         "Provider-only scope for this collapsed tag key. Invalid when filter is set; include provider restrictions in filter instead. Defaults to all providers.",
+							MarkdownDescription: "Provider-only scope for this collapsed tag key. Invalid when filter is set; include provider restrictions in filter instead. Defaults to all providers.",
 						},
 					},
 					CustomType: CollapsedTagKeysType{


### PR DESCRIPTION
## Changes

Regenerated with `make generate` first, then my changes.

Support for the new attributes on Business Metrics. `calculation_type` and `label` are part of the new features. 

## Testing

I had a locally running `core` instance and executed with success:

```
TF_ACC=1 go test ./vantage/ -count=1 -run 'TestAccBusinessMetric' -v
```
