### PR TITLE
[FIN-4150] Add Count support to Cost Reports

### DIFF
--- a/docs/resources/cost_report.md
+++ b/docs/resources/cost_report.md
@@ -18,9 +18,9 @@ resource "vantage_cost_report" "demo_report" {
   folder_token        = "fldr_3555785cd0409118"
   filter              = "costs.provider = 'aws'"
   saved_filter_tokens = ["svd_fltr_e844a2ccace05933", "svd_fltr_1b4b80a380ef4ba2"]
-  workspace_token = "wrkspc_47c3254c790e9351"
-  chart_type = "line" # Allowed: area, line, pie, bar, multi-bar
-  date_bin = "day"    # Allowed: cumulative, day, week, month, quarter
+  workspace_token     = "wrkspc_47c3254c790e9351"
+  chart_type          = "line" # Allowed: area, line, pie, bar, multi-bar
+  date_bin            = "day"  # Allowed: cumulative, day, week, month, quarter
 
   settings = {
     include_credits      = true
@@ -29,7 +29,7 @@ resource "vantage_cost_report" "demo_report" {
     include_tax          = true
     amortize             = false
     unallocated          = false
-    aggregate_by         = "cost" # Allowed: cost, usage
+    aggregate_by         = "cost" # Allowed: cost, usage, count
     show_previous_period = false
   }
 
@@ -73,7 +73,7 @@ resource "vantage_cost_report" "demo_report" {
 Optional:
 
 - `x_axis_dimension` (List of String) The dimension used to group or label data along the x-axis (e.g., by date, region, or service). NOTE: Only one value is allowed at this time. Defaults to ['date'].
-- `y_axis_dimension` (String) The metric or measure displayed on the chart's y-axis. Possible values: 'cost', 'usage'. Defaults to 'cost'.
+- `y_axis_dimension` (String) The metric or measure displayed on the chart's y-axis. Possible values: 'cost', 'usage', 'count'. Defaults to 'cost'.
 
 
 <a id="nestedatt--settings"></a>
@@ -81,13 +81,11 @@ Optional:
 
 Optional:
 
-- `aggregate_by` (String) Report will aggregate by cost or usage.
+- `aggregate_by` (String) Report will aggregate by cost, usage, or count.
 - `amortize` (Boolean) Report will amortize.
 - `include_credits` (Boolean) Report will include credits.
 - `include_discounts` (Boolean) Report will include discounts.
 - `include_refunds` (Boolean) Report will include refunds.
 - `include_tax` (Boolean) Report will include tax.
-- `show_previous_period` (Boolean) Report will show previous period costs or usage comparison.
+- `show_previous_period` (Boolean) Report will show previous period cost, usage, or count comparison.
 - `unallocated` (Boolean) Report will show unallocated costs.
-
-

--- a/examples/resources/vantage_cost_report/resource.tf
+++ b/examples/resources/vantage_cost_report/resource.tf
@@ -3,9 +3,9 @@ resource "vantage_cost_report" "demo_report" {
   folder_token        = "fldr_3555785cd0409118"
   filter              = "costs.provider = 'aws'"
   saved_filter_tokens = ["svd_fltr_e844a2ccace05933", "svd_fltr_1b4b80a380ef4ba2"]
-  workspace_token = "wrkspc_47c3254c790e9351"
-  chart_type = "line" # Allowed: area, line, pie, bar, multi-bar
-  date_bin = "day"    # Allowed: cumulative, day, week, month, quarter
+  workspace_token     = "wrkspc_47c3254c790e9351"
+  chart_type          = "line" # Allowed: area, line, pie, bar, multi-bar
+  date_bin            = "day"  # Allowed: cumulative, day, week, month, quarter
 
   settings = {
     include_credits      = true
@@ -14,7 +14,7 @@ resource "vantage_cost_report" "demo_report" {
     include_tax          = true
     amortize             = false
     unallocated          = false
-    aggregate_by         = "cost" # Allowed: cost, usage
+    aggregate_by         = "cost" # Allowed: cost, usage, count
     show_previous_period = false
   }
 

--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -196,9 +196,12 @@ func (r CostReportResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed:            true,
 					},
 					"y_axis_dimension": schema.StringAttribute{
-						MarkdownDescription: "The metric or measure displayed on the chart's y-axis. Possible values: 'cost', 'usage'. Defaults to 'cost'.",
+						MarkdownDescription: "The metric or measure displayed on the chart's y-axis. Possible values: 'cost', 'usage', 'count'. Defaults to 'cost'.",
 						Optional:            true,
 						Computed:            true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("cost", "usage", "count"),
+						},
 					},
 				},
 			},
@@ -250,15 +253,15 @@ func (r CostReportResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed:            true,
 					},
 					"aggregate_by": schema.StringAttribute{
-						MarkdownDescription: "Report will aggregate by cost or usage.",
+						MarkdownDescription: "Report will aggregate by cost, usage, or count.",
 						Optional:            true,
 						Computed:            true,
 						Validators: []validator.String{
-							stringvalidator.OneOf("cost", "usage"),
+							stringvalidator.OneOf("cost", "usage", "count"),
 						},
 					},
 					"show_previous_period": schema.BoolAttribute{
-						MarkdownDescription: "Report will show previous period costs or usage comparison.",
+						MarkdownDescription: "Report will show previous period cost, usage, or count comparison.",
 						Optional:            true,
 						Computed:            true,
 					},

--- a/vantage/cost_report_resource.go
+++ b/vantage/cost_report_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -218,9 +217,6 @@ func (r CostReportResource) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "Settings for the Cost Report.",
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
 				Attributes: map[string]schema.Attribute{
 					"include_credits": schema.BoolAttribute{
 						MarkdownDescription: "Report will include credits.",

--- a/vantage/cost_report_resource_test.go
+++ b/vantage/cost_report_resource_test.go
@@ -161,7 +161,7 @@ func TestAccCostReport_settings(t *testing.T) {
 				),
 			},
 			{ // update settings
-				Config: costReportWithSettings("test-settings", "test-settings", false, false, false, false, true, true, "usage", true),
+				Config: costReportWithSettings("test-settings", "test-settings", false, false, false, false, true, true, "count", true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.include_credits", "false"),
 					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.include_refunds", "false"),
@@ -169,12 +169,12 @@ func TestAccCostReport_settings(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.include_tax", "false"),
 					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.amortize", "true"),
 					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.unallocated", "true"),
-					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.aggregate_by", "usage"),
+					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.aggregate_by", "count"),
 					resource.TestCheckResourceAttr("vantage_cost_report.test-settings", "settings.show_previous_period", "true"),
 				),
 			},
 			{ // confirm no drift
-				Config:             costReportWithSettings("test-settings", "test-settings", false, false, false, false, true, true, "usage", true),
+				Config:             costReportWithSettings("test-settings", "test-settings", false, false, false, false, true, true, "count", true),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -220,15 +220,15 @@ func TestAccCostReport_chartSettings(t *testing.T) {
 				),
 			},
 			{ // update chart_settings
-				Config: costReportWithChartSettings("test-cs", "test-chart-settings", "service", "usage"),
+				Config: costReportWithChartSettings("test-cs", "test-chart-settings", "service", "count"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vantage_cost_report.test-cs", "chart_settings.x_axis_dimension.#", "1"),
 					resource.TestCheckResourceAttr("vantage_cost_report.test-cs", "chart_settings.x_axis_dimension.0", "service"),
-					resource.TestCheckResourceAttr("vantage_cost_report.test-cs", "chart_settings.y_axis_dimension", "usage"),
+					resource.TestCheckResourceAttr("vantage_cost_report.test-cs", "chart_settings.y_axis_dimension", "count"),
 				),
 			},
 			{ // confirm no drift
-				Config:             costReportWithChartSettings("test-cs", "test-chart-settings", "service", "usage"),
+				Config:             costReportWithChartSettings("test-cs", "test-chart-settings", "service", "count"),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},


### PR DESCRIPTION
### Problem

Terraform validation and documentation reject the Count display mode. The Cost Report resource also pins the API-computed `settings` object to its prior state, so an API response that synchronizes `settings.aggregate_by` with a changed `chart_settings.y_axis_dimension` is rejected as an inconsistent apply result.

### Solution

- Allow `count` for Cost Report aggregate and y-axis settings.
- Let omitted computed settings remain unknown during planning so the API can synchronize the two display-mode fields.
- Update resource documentation and Count acceptance coverage.

### Validation

- `go test ./...` with Go 1.26.4
- Focused Cost Report settings and chart-settings acceptance tests against vantage-sh/core#20622

### Rollout

Release this provider change before merging [vantage-sh/core#20622](https://github.com/vantage-sh/core/pull/20622). The core PR's latest-release provider check depends on this planning behavior.
