### PR TITLE
chore: Update CODEOWNERS to point to engineering approvers and Persona teams.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-# Dependabot dependency manifests — @vantage-sh/engineering-platform
+* @vantage-sh/engineering-persona
+# Dependabot dependency manifests — @vantage-sh/engineering-approvers
 # Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, gomod).
-/.github/workflows/**/* @vantage-sh/engineering-platform
-/go.mod @vantage-sh/engineering-platform
-/go.sum @vantage-sh/engineering-platform
+/.github/workflows/**/* @vantage-sh/engineering-approvers
+/go.mod @vantage-sh/engineering-approvers
+/go.sum @vantage-sh/engineering-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @vantage-sh/engineering-persona
 # Dependabot dependency manifests — @vantage-sh/engineering-approvers
 # Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, gomod).
-/.github/workflows/**/* @vantage-sh/engineering-approvers
-/go.mod @vantage-sh/engineering-approvers
-/go.sum @vantage-sh/engineering-approvers
+/.github/workflows/**/* @vantage-sh/engineering-persona @vantage-sh/engineering-approvers
+/go.mod @vantage-sh/engineering-persona @vantage-sh/engineering-approvers
+/go.sum @vantage-sh/engineering-persona @vantage-sh/engineering-approvers


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only change to review routing; no application or runtime behavior is affected.
> 
> **Overview**
> Updates **CODEOWNERS** so GitHub review ownership no longer points at `@vantage-sh/engineering-platform`.
> 
> The default owner (`*`) is now `@vantage-sh/engineering-persona`. Paths for **GitHub Actions workflows**, **`go.mod`**, and **`go.sum`** require both `@vantage-sh/engineering-persona` and `@vantage-sh/engineering-approvers`. The Dependabot-related comment is updated to reference the approvers team.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee0230c88f992906d5cb49f1acda8f6a0d31ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->