### PR TITLE
Fix conflicting team member fields on update

### DIFF
--- a/vantage/team_resource.go
+++ b/vantage/team_resource.go
@@ -243,27 +243,38 @@ func (r TeamResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	params := teamsv2.NewUpdateTeamParams()
 	params.WithTeamToken(data.Token.ValueString())
 
-	userTokens := []string{}
-	userEmails := []string{}
+        userTokens := []string{}
+        userEmails := []string{}
 
-	// The API accepts user_tokens or user_emails, but rejects requests that
-	// contain both as non-empty arrays. Read populates both computed fields, so
-	// use config to preserve the identifier type selected by the practitioner.
-	// Imported teams have neither field in config; prefer tokens for them.
-	switch {
-	case !config.UserTokens.IsNull() && !config.UserTokens.IsUnknown():
-		if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
-			resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
-		}
-	case !config.UserEmails.IsNull() && !config.UserEmails.IsUnknown():
-		if !data.UserEmails.IsNull() && !data.UserEmails.IsUnknown() {
-			resp.Diagnostics.Append(data.UserEmails.ElementsAs(ctx, &userEmails, false)...)
-		}
-	default:
-		if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
-			resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
-		}
-	}
+        userTokensConfigured := !config.UserTokens.IsNull() && !config.UserTokens.IsUnknown()
+        userEmailsConfigured := !config.UserEmails.IsNull() && !config.UserEmails.IsUnknown()
+        userTokensNonEmpty := userTokensConfigured && len(config.UserTokens.Elements()) > 0
+        userEmailsNonEmpty := userEmailsConfigured && len(config.UserEmails.Elements()) > 0
+
+        // The API accepts user_tokens or user_emails, but rejects requests that
+        // contain both as non-empty arrays. Read populates both computed fields, so
+        // use config to preserve the identifier type selected by the practitioner.
+        // Imported teams have neither field in config; prefer tokens for them.
+        switch {
+        case userTokensNonEmpty && userEmailsNonEmpty:
+                resp.Diagnostics.AddError(
+                        "Conflicting Team Members",
+                        "user_tokens and user_emails cannot both be non-empty.",
+                )
+                return
+        case userTokensNonEmpty, userTokensConfigured && !userEmailsNonEmpty:
+                if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
+                        resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
+                }
+        case userEmailsNonEmpty, userEmailsConfigured:
+                if !data.UserEmails.IsNull() && !data.UserEmails.IsUnknown() {
+                        resp.Diagnostics.Append(data.UserEmails.ElementsAs(ctx, &userEmails, false)...)
+                }
+        default:
+                if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
+                        resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
+                }
+        }
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/vantage/team_resource.go
+++ b/vantage/team_resource.go
@@ -234,47 +234,48 @@ func (r TeamResource) ImportState(ctx context.Context, req resource.ImportStateR
 }
 
 func (r TeamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data, config *resource_team.TeamModel
+	var data, config, state *resource_team.TeamModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	params := teamsv2.NewUpdateTeamParams()
 	params.WithTeamToken(data.Token.ValueString())
 
-        userTokens := []string{}
-        userEmails := []string{}
+	userTokens := []string{}
+	userEmails := []string{}
 
-        userTokensConfigured := !config.UserTokens.IsNull() && !config.UserTokens.IsUnknown()
-        userEmailsConfigured := !config.UserEmails.IsNull() && !config.UserEmails.IsUnknown()
-        userTokensNonEmpty := userTokensConfigured && len(config.UserTokens.Elements()) > 0
-        userEmailsNonEmpty := userEmailsConfigured && len(config.UserEmails.Elements()) > 0
+	userTokensConfigured := !config.UserTokens.IsNull() && !config.UserTokens.IsUnknown()
+	userEmailsConfigured := !config.UserEmails.IsNull() && !config.UserEmails.IsUnknown()
+	userTokensNonEmpty := userTokensConfigured && len(config.UserTokens.Elements()) > 0
+	userEmailsNonEmpty := userEmailsConfigured && len(config.UserEmails.Elements()) > 0
 
-        // The API accepts user_tokens or user_emails, but rejects requests that
-        // contain both as non-empty arrays. Read populates both computed fields, so
-        // use config to preserve the identifier type selected by the practitioner.
-        // Imported teams have neither field in config; prefer tokens for them.
-        switch {
-        case userTokensNonEmpty && userEmailsNonEmpty:
-                resp.Diagnostics.AddError(
-                        "Conflicting Team Members",
-                        "user_tokens and user_emails cannot both be non-empty.",
-                )
-                return
-        case userTokensNonEmpty, userTokensConfigured && !userEmailsNonEmpty:
-                if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
-                        resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
-                }
-        case userEmailsNonEmpty, userEmailsConfigured:
-                if !data.UserEmails.IsNull() && !data.UserEmails.IsUnknown() {
-                        resp.Diagnostics.Append(data.UserEmails.ElementsAs(ctx, &userEmails, false)...)
-                }
-        default:
-                if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
-                        resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
-                }
-        }
+	// The API accepts user_tokens or user_emails, but rejects requests that
+	// contain both as non-empty arrays. Read populates both computed fields, so
+	// use config to preserve the identifier type selected by the practitioner.
+	// Imported teams have neither field in config; prefer tokens for them.
+	switch {
+	case userTokensNonEmpty && userEmailsNonEmpty:
+		resp.Diagnostics.AddError(
+			"Conflicting Team Members",
+			"user_tokens and user_emails cannot both be non-empty.",
+		)
+		return
+	case userTokensNonEmpty, userTokensConfigured && !userEmailsNonEmpty:
+		if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
+			resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
+		}
+	case userEmailsNonEmpty, userEmailsConfigured:
+		if !data.UserEmails.IsNull() && !data.UserEmails.IsUnknown() {
+			resp.Diagnostics.Append(data.UserEmails.ElementsAs(ctx, &userEmails, false)...)
+		}
+	default:
+		if !state.UserTokens.IsNull() && !state.UserTokens.IsUnknown() {
+			resp.Diagnostics.Append(state.UserTokens.ElementsAs(ctx, &userTokens, false)...)
+		}
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/vantage/team_resource.go
+++ b/vantage/team_resource.go
@@ -224,6 +224,12 @@ func (r TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 	state.WorkspaceTokens = workspaceTokensValue
 
+	// Role is not returned by the API, so preserve the create/update default
+	// when initializing state during import.
+	if state.Role.IsNull() || state.Role.IsUnknown() {
+		state.Role = types.StringValue("editor")
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/vantage/team_resource.go
+++ b/vantage/team_resource.go
@@ -234,37 +234,47 @@ func (r TeamResource) ImportState(ctx context.Context, req resource.ImportStateR
 }
 
 func (r TeamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data *resource_team.TeamModel
+	var data, config *resource_team.TeamModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	params := teamsv2.NewUpdateTeamParams()
 	params.WithTeamToken(data.Token.ValueString())
 
-	userTokensList, diag := types.ListValueFrom(ctx, types.StringType, data.UserTokens)
-	if diag.HasError() {
-		resp.Diagnostics.Append(diag...)
+	userTokens := []string{}
+	userEmails := []string{}
+
+	// The API accepts user_tokens or user_emails, but rejects requests that
+	// contain both as non-empty arrays. Read populates both computed fields, so
+	// use config to preserve the identifier type selected by the practitioner.
+	// Imported teams have neither field in config; prefer tokens for them.
+	switch {
+	case !config.UserTokens.IsNull() && !config.UserTokens.IsUnknown():
+		if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
+			resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
+		}
+	case !config.UserEmails.IsNull() && !config.UserEmails.IsUnknown():
+		if !data.UserEmails.IsNull() && !data.UserEmails.IsUnknown() {
+			resp.Diagnostics.Append(data.UserEmails.ElementsAs(ctx, &userEmails, false)...)
+		}
+	default:
+		if !data.UserTokens.IsNull() && !data.UserTokens.IsUnknown() {
+			resp.Diagnostics.Append(data.UserTokens.ElementsAs(ctx, &userTokens, false)...)
+		}
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	var userTokens []string
-	userTokensList.ElementsAs(ctx, &userTokens, false)
-
-	userEmailsList, diag := types.ListValueFrom(ctx, types.StringType, data.UserEmails)
-	if diag.HasError() {
-		resp.Diagnostics.Append(diag...)
+	workspaceTokens := []string{}
+	if !data.WorkspaceTokens.IsNull() && !data.WorkspaceTokens.IsUnknown() {
+		resp.Diagnostics.Append(data.WorkspaceTokens.ElementsAs(ctx, &workspaceTokens, false)...)
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
-	var userEmails []string
-	userEmailsList.ElementsAs(ctx, &userEmails, false)
-	workspaceTokensList, diag := types.ListValueFrom(ctx, types.StringType, data.WorkspaceTokens)
-	if diag.HasError() {
-		resp.Diagnostics.Append(diag...)
-		return
-	}
-	var workspaceTokens []string
-	workspaceTokensList.ElementsAs(ctx, &workspaceTokens, false)
 
 	model := &modelsv2.UpdateTeam{
 		Name:                  data.Name.ValueString(),

--- a/vantage/team_resource_test.go
+++ b/vantage/team_resource_test.go
@@ -63,6 +63,21 @@ func TestTeam(t *testing.T) {
 					resource.TestCheckResourceAttr("vantage_team.team", "user_emails.#", "1"),
 				),
 			},
+			{
+				// update only the description after Read populates both user fields
+				Config: testAccTeamWithIgnoredUsers(rUpdatedName, "updated description"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vantage_team.team", "name", rUpdatedName),
+					resource.TestCheckResourceAttr("vantage_team.team", "description", "updated description"),
+					resource.TestCheckResourceAttr("vantage_team.team", "user_tokens.#", "1"),
+					resource.TestCheckResourceAttr("vantage_team.team", "user_emails.#", "1"),
+				),
+			},
+			{
+				Config:             testAccTeamWithIgnoredUsers(rUpdatedName, "updated description"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }
@@ -165,8 +180,6 @@ resource "vantage_team" "team" {
 `, title)
 }
 
-
-
 func testAccTeamWithUserTokens(title, description string) string {
 	return fmt.Sprintf(`
 data "vantage_workspaces" "test" {}
@@ -175,6 +188,20 @@ resource "vantage_team" "team" {
 	user_tokens = [data.vantage_users.test.users[0].token]
 	name = %[1]q
 	description = %[2]q
+}
+	`, title, description)
+}
+
+func testAccTeamWithIgnoredUsers(title, description string) string {
+	return fmt.Sprintf(`
+data "vantage_workspaces" "test" {}
+resource "vantage_team" "team" {
+	name = %[1]q
+	description = %[2]q
+
+	lifecycle {
+		ignore_changes = [user_emails, user_tokens]
+	}
 }
 	`, title, description)
 }

--- a/vantage/team_resource_test.go
+++ b/vantage/team_resource_test.go
@@ -64,8 +64,13 @@ func TestTeam(t *testing.T) {
 				),
 			},
 			{
-				// update only the description after Read populates both user fields
-				Config: testAccTeamWithIgnoredUsers(rUpdatedName, "updated description"),
+				ResourceName:      "vantage_team.team",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// update only the description after import populates both user fields
+				Config: testAccTeamWithDescription(rUpdatedName, "updated description"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vantage_team.team", "name", rUpdatedName),
 					resource.TestCheckResourceAttr("vantage_team.team", "description", "updated description"),
@@ -74,7 +79,7 @@ func TestTeam(t *testing.T) {
 				),
 			},
 			{
-				Config:             testAccTeamWithIgnoredUsers(rUpdatedName, "updated description"),
+				Config:             testAccTeamWithDescription(rUpdatedName, "updated description"),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -188,20 +193,6 @@ resource "vantage_team" "team" {
 	user_tokens = [data.vantage_users.test.users[0].token]
 	name = %[1]q
 	description = %[2]q
-}
-	`, title, description)
-}
-
-func testAccTeamWithIgnoredUsers(title, description string) string {
-	return fmt.Sprintf(`
-data "vantage_workspaces" "test" {}
-resource "vantage_team" "team" {
-	name = %[1]q
-	description = %[2]q
-
-	lifecycle {
-		ignore_changes = [user_emails, user_tokens]
-	}
 }
 	`, title, description)
 }


### PR DESCRIPTION
a team can define which users belong to the team by listing user tokens or user emails in its TF config. once created, the team has both user emails and user tokens in its config, returned by the response from the GET. 

customer encounters a problem when updating description of existing team. when updating the team's description via PUT, the request includes both emails and tokens - this hits 400 in the API because we do not allow both to be present in the request body at the same time.

this PR changes behavior in the provider to pass only user tokens if user tokens are used in the config, or user emails if user emails are used in the config, but not both.

agent session here: https://cursor.com/dashboard/shared-chats?shareId=terraform-provider-issue-review-vCGZufQSsJjf

## Summary
- send only the configured team member identifier type during updates
- fall back to user tokens for imported or externally managed teams
- cover description-only updates with ignored member fields and verify no drift

## Test plan
- [x] `TF_ACC=1 go test ./vantage -run '^TestTeam$' -v -count=1`
- [x] `go test ./... -run '^$'`
- [ ] `TF_ACC=1 make test` (unrelated account permission failures and API rate limiting)

## Ticket
[ENG-2821](https://linear.app/vantage-sh/issue/ENG-2821/schueco-test-or-terraform-vantage-team-update-fails-with-400-due-to)

Made with [Cursor](https://cursor.com)