### PR TITLE
fix: Send false report forecast default updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/vantage-sh/vantage-go v0.1.6
+	github.com/vantage-sh/vantage-go v0.1.7-0.20260730152126-0832b846bb17
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/vantage-sh/vantage-go v0.1.7-0.20260730152126-0832b846bb17
+	github.com/vantage-sh/vantage-go v0.1.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vantage-sh/vantage-go v0.1.7-0.20260730152126-0832b846bb17 h1:zmQpuG4mrsnwJNVO3U7caXo6IiRQOmUX8ywztEbPVcQ=
-github.com/vantage-sh/vantage-go v0.1.7-0.20260730152126-0832b846bb17/go.mod h1:+AplFOIL/egitn/MvmQXPS4hQw7Yi61+H3HglnVWwpU=
+github.com/vantage-sh/vantage-go v0.1.7 h1:xLx2fMN92PmpKKJT5z8RocXb083/yx8HTvZsWTSs8l8=
+github.com/vantage-sh/vantage-go v0.1.7/go.mod h1:+AplFOIL/egitn/MvmQXPS4hQw7Yi61+H3HglnVWwpU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vantage-sh/vantage-go v0.1.6 h1:K08j8Cyv2FUXVRAkdzMRoUaaXc5vhVZ1cA/OLb3G9gw=
-github.com/vantage-sh/vantage-go v0.1.6/go.mod h1:+AplFOIL/egitn/MvmQXPS4hQw7Yi61+H3HglnVWwpU=
+github.com/vantage-sh/vantage-go v0.1.7-0.20260730152126-0832b846bb17 h1:zmQpuG4mrsnwJNVO3U7caXo6IiRQOmUX8ywztEbPVcQ=
+github.com/vantage-sh/vantage-go v0.1.7-0.20260730152126-0832b846bb17/go.mod h1:+AplFOIL/egitn/MvmQXPS4hQw7Yi61+H3HglnVWwpU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/vantage/report_forecast_resource_model.go
+++ b/vantage/report_forecast_resource_model.go
@@ -50,7 +50,7 @@ func (m *reportForecastModel) toCreate(ctx context.Context, diags *diag.Diagnost
 		dst.BusinessMetricToken = m.BusinessMetricToken.ValueStringPointer()
 	}
 	if !m.SetAsDefault.IsNull() && !m.SetAsDefault.IsUnknown() {
-		dst.SetAsDefault = m.SetAsDefault.ValueBool()
+		dst.SetAsDefault = m.SetAsDefault.ValueBoolPointer()
 	}
 
 	if !m.ScenarioModelTokens.IsNull() && !m.ScenarioModelTokens.IsUnknown() {
@@ -78,7 +78,7 @@ func (m *reportForecastModel) toUpdate(ctx context.Context, diags *diag.Diagnost
 		dst.BusinessMetricToken = m.BusinessMetricToken.ValueStringPointer()
 	}
 	if !m.SetAsDefault.IsNull() && !m.SetAsDefault.IsUnknown() {
-		dst.SetAsDefault = m.SetAsDefault.ValueBool()
+		dst.SetAsDefault = m.SetAsDefault.ValueBoolPointer()
 	}
 
 	if !m.ScenarioModelTokens.IsNull() && !m.ScenarioModelTokens.IsUnknown() {

--- a/vantage/report_forecast_resource_test.go
+++ b/vantage/report_forecast_resource_test.go
@@ -20,7 +20,6 @@ func TestAccVantageReportForecast_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				// Exercise set_as_default on create; updating it alone currently 500s in prod.
 				Config: testAccVantageReportForecastConfig_basic(rTitle, modelTitle, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "title", rTitle),
@@ -39,16 +38,16 @@ func TestAccVantageReportForecast_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"set_as_default"},
 			},
 			{
-				Config: testAccVantageReportForecastConfig_basic(rUpdatedTitle, modelTitle, true),
+				Config: testAccVantageReportForecastConfig_basic(rUpdatedTitle, modelTitle, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "title", rUpdatedTitle),
-					resource.TestCheckResourceAttr(resourceName, "set_as_default", "true"),
-					resource.TestCheckResourceAttr(resourceName, "is_default", "true"),
+					resource.TestCheckResourceAttr(resourceName, "set_as_default", "false"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
 					resource.TestCheckResourceAttr(resourceName, "scenario_model_tokens.#", "1"),
 				),
 			},
 			{
-				Config:             testAccVantageReportForecastConfig_basic(rUpdatedTitle, modelTitle, true),
+				Config:             testAccVantageReportForecastConfig_basic(rUpdatedTitle, modelTitle, false),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -114,10 +113,7 @@ func testAccVantageReportForecastConfig_basic(title, modelTitle string, setAsDef
 }
 
 func testAccVantageReportForecastConfig_basicNamed(title, modelTitle, resourceLabel string, setAsDefault bool) string {
-	setAsDefaultLine := ""
-	if setAsDefault {
-		setAsDefaultLine = "\n  set_as_default        = true"
-	}
+	setAsDefaultLine := fmt.Sprintf("\n  set_as_default        = %t", setAsDefault)
 
 	return fmt.Sprintf(`
 data "vantage_workspaces" "test" {}


### PR DESCRIPTION
## Summary
- use the nullable `set_as_default` pointer generated by `vantage-go`
- send explicit `false` values instead of dropping them through JSON `omitempty`
- extend acceptance coverage to toggle a default forecast off and verify no drift
- consume the released `vantage-go` v0.1.7 client

## Test plan
- [x] `go test ./...`
- [x] `TF_ACC=1 go test -v ./vantage -run 'TestAccVantageReportForecast_basic$' -count=1` against the Core and `vantage-go` feature branches

Depends on:
- https://github.com/vantage-sh/core/pull/20840
- https://github.com/vantage-sh/vantage-go/pull/100

Made with [Cursor](https://cursor.com)